### PR TITLE
feat: index refresh if dir already exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,10 @@ async fn app(
   let suffix = Uuid::new_v4();
   let index_dir_path = format!("/tmp/index-{suffix}");
   create_dir(&index_dir_path).unwrap();
-  let tsldb = Tsldb::new(&index_dir_path);
+  let tsldb = match Tsldb::new(&index_dir_path) {
+    Ok(tsldb) => tsldb,
+    Err(err) => panic!("Unable to initialize tsldb with err {}", err),
+  };
 
   // Create RabbitMQ to store incoming requests.
   let queue = create_queue(container_name, image_name, image_tag).await;

--- a/tsldb/src/index_manager/index.rs
+++ b/tsldb/src/index_manager/index.rs
@@ -985,8 +985,8 @@ mod tests {
     index.commit(true);
 
     // Create one more new index using same dir location
-    let index2 = Index::new_with_max_params(index_dir_path, 1, 1).unwrap();
-    let search_result = index2.search(
+    let index = Index::new_with_max_params(index_dir_path, 1, 1).unwrap();
+    let search_result = index.search(
       "some_message_1",
       start_time as u64,
       Utc::now().timestamp_millis() as u64,

--- a/tsldb/src/index_manager/metadata.rs
+++ b/tsldb/src/index_manager/metadata.rs
@@ -19,11 +19,13 @@ pub struct Metadata {
 
   /// Maximum number of log messages per segment. This is only approximate and a segment can
   /// contain more messages than this number depending on the frequecy at which commit() is called.
-  approx_max_log_message_count_per_segment: u32,
+  #[serde(with = "atomic_cell_serde")]
+  approx_max_log_message_count_per_segment:  AtomicCell<u32>,
 
   /// Maximum number of data points per segment. This is only approximate and a segment can
   /// contain more data points than this number depending on the frequecy at which commit() is called.
-  approx_max_data_point_count_per_segment: u32,
+  #[serde(with = "atomic_cell_serde")]
+  approx_max_data_point_count_per_segment:  AtomicCell<u32>,
 }
 
 impl Metadata {
@@ -37,8 +39,8 @@ impl Metadata {
     Metadata {
       segment_count: AtomicCell::new(segment_count),
       current_segment_number: AtomicCell::new(current_segment_number),
-      approx_max_log_message_count_per_segment: max_log_messges,
-      approx_max_data_point_count_per_segment: max_data_points,
+      approx_max_log_message_count_per_segment: AtomicCell::new(max_log_messges),
+      approx_max_data_point_count_per_segment: AtomicCell::new(max_data_points),
     }
   }
 
@@ -65,12 +67,22 @@ impl Metadata {
 
   /// Get the (approx) max log message count per segment.
   pub fn get_approx_max_log_message_count_per_segment(&self) -> u32 {
-    self.approx_max_log_message_count_per_segment
+    self.approx_max_log_message_count_per_segment.load()
   }
 
   /// Get the (approx) max data point count per segment.
   pub fn get_approx_max_data_point_count_per_segment(&self) -> u32 {
-    self.approx_max_data_point_count_per_segment
+    self.approx_max_data_point_count_per_segment.load()
+  }
+
+  /// Update the current segment number to the given value.
+  pub fn update_max_log_message_count_per_segment(&self, value: u32) {
+    self.approx_max_log_message_count_per_segment.store(value);
+  }
+
+  /// Update the current segment number to the given value.
+  pub fn update_max_data_point_count_per_segment(&self, value: u32) {
+    self.approx_max_data_point_count_per_segment.store(value);
   }
 }
 

--- a/tsldb/src/lib.rs
+++ b/tsldb/src/lib.rs
@@ -6,6 +6,8 @@ pub(crate) mod utils;
 
 use std::collections::HashMap;
 
+use utils::error::TsldbError;
+
 use crate::index_manager::index::Index;
 use crate::log::log_message::LogMessage;
 use crate::ts::data_point::DataPoint;
@@ -18,9 +20,15 @@ pub struct Tsldb {
 
 impl Tsldb {
   /// Create a new tsldb at the given directory path.
-  pub fn new(index_dir_path: &str) -> Self {
-    let index = Index::new(index_dir_path);
-    Tsldb { index }
+  pub fn new(index_dir_path: &str) -> Result<Self, TsldbError> {
+    match Index::new(index_dir_path) {
+      Ok(index) => {
+         Ok(Tsldb { index })
+      }
+      Err(err) => {
+        Err(err)
+      }
+    }
   }
 
   /// Create a new tsldb at the given directory path, with specified parameters for
@@ -29,9 +37,15 @@ impl Tsldb {
     index_dir_path: &str,
     max_log_messages: u32,
     max_data_points: u32,
-  ) -> Self {
-    let index = Index::new_with_max_params(index_dir_path, max_log_messages, max_data_points);
-    Tsldb { index }
+  ) -> Result<Self, TsldbError> {
+    match Index::new_with_max_params(index_dir_path, max_log_messages, max_data_points) {
+      Ok(index) => { 
+        Ok(Tsldb {index})
+      }
+      Err(err) => {
+        Err(err)
+      }
+    }
   }
 
   /// Append a log message.


### PR DESCRIPTION
@vinaykakade if someone is changing metadata values should we still do a refresh and update metadata manually or skip refresh from segment?