### PR TITLE
feat: allow configuration of port number on which infino server runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ Cargo.lock
 
 # vscode configuration
 .vscode
+
+# the index created by tsldb if default config is used
+index

--- a/config/default.toml
+++ b/config/default.toml
@@ -4,6 +4,7 @@ num_log_messages_threshold = 100000
 num_data_points_threshold = 100000
 
 [server]
+port = 3000
 commit_interval_in_seconds = 30
 
 [rabbitmq]

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -8,12 +8,18 @@ const DEFAULT_CONFIG_FILE_NAME: &str = "default.toml";
 /// Settings for infino server.
 pub struct ServerSettings {
   commit_interval_in_seconds: u32,
+  port: u16,
 }
 
 impl ServerSettings {
   /// Get the commit interval in seconds.
   pub fn get_commit_interval_in_seconds(&self) -> u32 {
     self.commit_interval_in_seconds
+  }
+
+  /// Get the port.
+  pub fn get_port(&self) -> u16 {
+    self.port
   }
 }
 
@@ -87,6 +93,7 @@ mod tests {
 
     let server_settings = settings.get_server_settings();
     assert_eq!(server_settings.get_commit_interval_in_seconds(), 30);
+    assert_eq!(server_settings.get_port(), 3000);
 
     let rabbitmq_settings = settings.get_rabbitmq_settings();
     assert_eq!(rabbitmq_settings.get_container_name(), "infino-queue");


### PR DESCRIPTION
## What does this PR do?

Allow configuration of port number on which port number runs

## How does this PR work? (optional)

the default.toml config has the default port number, which can be overridden by usual methods, such as specifying it in the RUN_MODE specific configuration, or in an environment variable.

## Refer to a related PR or issue link

Issue #23 

## Checklist

- [X ]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)

