### PR TITLE
bugfix: run tests on different rabbitmq ports to avoid port conflict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,13 +51,6 @@ repos:
         args: ["--", "-D", "warnings"]
         types: [rust]
         pass_filenames: false
-      - id: cargo-test-infino-ignored
-        name: cargo test infino ignored
-        description: Run Ignored cargo test
-        entry: cargo test -- --ignored
-        language: system
-        types: [rust]
-        pass_filenames: false
 # Commenting out until we figure out how to pass env vars in 'entry'.
 #      - id: cargo-test-tsldb-loom
 #        name: cargo test infino loom

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ features = [
 
 [dev-dependencies]
 tower = { version = "0.4", features = ["util"] }
-serial_test = "2.0.0"
 tempdir = "*"
 
 [profile.release]

--- a/config/default.toml
+++ b/config/default.toml
@@ -10,3 +10,5 @@ timestamp_key = "date"
 
 [rabbitmq]
 container_name = "infino-queue"
+stream_port = 5552
+listen_port = 5672

--- a/src/utils/docker.rs
+++ b/src/utils/docker.rs
@@ -1,5 +1,7 @@
 use std::process::Command;
 
+use log::info;
+
 /// Start a docker container with the given name and image.
 pub fn start_docker_container(
   name: &str,
@@ -17,7 +19,7 @@ pub fn start_docker_container(
     .args(extra_args)
     .arg(format!("{}:{}", image_name, image_tag));
 
-  println!("Running command: {:?}", command);
+  info!("Running command: {:?}", command);
 
   // Run the Docker command
   let output = command.output()?;

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -33,12 +33,24 @@ impl ServerSettings {
 /// Settings for rabbitmq queue.
 pub struct RabbitMQSettings {
   container_name: String,
+  listen_port: u16,
+  stream_port: u16,
 }
 
 impl RabbitMQSettings {
   /// Get comtainer name for rabbitmq docker container.
   pub fn get_container_name(&self) -> &str {
     &self.container_name
+  }
+
+  /// Get listen port for the queue.
+  pub fn get_listen_port(&self) -> u16 {
+    self.listen_port
+  }
+
+  /// Get stream port for the queue.
+  pub fn get_stream_port(&self) -> u16 {
+    self.stream_port
   }
 }
 
@@ -106,5 +118,7 @@ mod tests {
     // Check rabbitmq settings.
     let rabbitmq_settings = settings.get_rabbitmq_settings();
     assert_eq!(rabbitmq_settings.get_container_name(), "infino-queue");
+    assert_eq!(rabbitmq_settings.get_listen_port(), 5672);
+    assert_eq!(rabbitmq_settings.get_stream_port(), 5552);
   }
 }


### PR DESCRIPTION
## What does this PR do?
- Allows to configure the docker mapping of the ports exposed by RabbitMQ, so that there isn't a port conflict across the tests as well as the tests and the Infino server.

## Refer to a related PR or issue link
- Issue #30 

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
