### PR TITLE
bugfix: Add graceful shutdown in Infino server

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod docker;
 pub(crate) mod error;
 pub(crate) mod settings;
+pub(crate) mod shutdown;

--- a/src/utils/shutdown.rs
+++ b/src/utils/shutdown.rs
@@ -1,0 +1,29 @@
+use log::info;
+use tokio::signal;
+
+/// Handle shuwdown signal.
+pub async fn shutdown_signal() {
+  let ctrl_c = async {
+    signal::ctrl_c()
+      .await
+      .expect("failed to install Ctrl+C handler");
+  };
+
+  #[cfg(unix)]
+  let terminate = async {
+    signal::unix::signal(signal::unix::SignalKind::terminate())
+      .expect("failed to install signal handler")
+      .recv()
+      .await;
+  };
+
+  #[cfg(not(unix))]
+  let terminate = std::future::pending::<()>();
+
+  tokio::select! {
+      _ = ctrl_c => {},
+      _ = terminate => {},
+  }
+
+  info!("Shutdown signal received, starting graceful shutdown. This may take several seconds...");
+}


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
By sending Ctrl-C signal to Infino server, the server, rabbitmq, as well as the commit thread now gracefully shuts down.

## How does this PR work?
The server is configured with a signal handler for Ctrl-C, which shuts down the above gracefully.

## Refer to a related PR or issue link
Issue #26 

## Checklist

- [X]  I have written the necessary rustdoc comments.
