### PR TITLE
feat: retires added with exponential backoff to rabbitmq connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1.12"
 tokio-executor-trait = "2.1.1"
 tokio-reactor-trait = "1.1.0"
+tokio-retry = "0.3"
 
 [dependencies.uuid]
 version = "1.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -372,10 +372,6 @@ mod tests {
     create_test_config(config_dir_path, index_dir_path, container_name);
     println!("Config dir path {}", config_dir_path);
 
-    // Stop any container from a prior test - useful in case of test failures if the container is
-    // left around without terminating it.
-    let _ = RabbitMQ::stop_queue_container(container_name);
-
     // Create the app.
     let (mut app, _, _, _) = app(config_dir_path, "rabbitmq", "3").await;
 


### PR DESCRIPTION
## What does this PR do?
- We try to connect to RabbitMq in exponential backoff fashion once docker is up and running

## How does this PR work? (optional)
- Once docker containers are up, we are not certain when they'll start running so we should keep trying to connect to it

## Refer to a related PR or issue link
- [(Related PR or issue)](https://github.com/infinohq/infino/issues/12)
