### PR TITLE
chore: bulk upload ES with some benchmark stat update

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -31,22 +31,24 @@ $ cargo run -r
 
 | dataset    | Elasticsearch | Tantivy       | Infino        |
 | ---------- | ------------- | ------------- | ------------- |
-| Apache Log | 3100000 bytes | 3207319 bytes | 1832848 bytes |
+| Apache Log | 2400000 bytes | 3207319 bytes | 1832848 bytes |
 
 ### Insertion speed
 
-| dataset    | Elasticsearch | Tantivy | Infino   |
-| ---------- | ------------- | ------- | -------- |
-| Apache Log | WIP           | 1.98s   | 313.64ms |
+| dataset    | Elasticsearch        | Tantivy | Infino   |
+| ---------- | -------------------- | ------- | -------- |
+| Apache Log | 3.68s (Over network) | 1.95s   | 315.23ms |
 
 ### Search latency
 
 Average across 5 runs for Apache log dataset
 
-| # of words in query | Elasticsearch | Tantivy  | Infino   |
-| ------------------- | ------------- | -------- | -------- |
-| 1                   | 54ms          | 277.17µs | 613.13µs |
-| 2                   | WIP           | 10.87ms  | 3.85ms   |
-| 3                   | WIP           | 4.79ms   | 648.21µs |
-| 4                   | WIP           | 37.58ms  | 5.35ms   |
-| 5                   | WIP           | 54.77ms  | 177.79µs |
+| # of words in query | Elasticsearch | Tantivy   | Infino    |
+| ------------------- | ------------- | --------- | --------- |
+| 1                   | 169 ms        | 2.85ms.   | 1.48ms.   |
+| 2                   | 7 ms          | 88.29µs.  | 17.75µs.  |
+| 3                   | 145 ms        | 2.54ms.   | 144.71ms. |
+| 4                   | 155 ms        | 3.99ms.   | 37.33ms.  |
+| 5                   | 135 ms        | 156.79µs. | 234.08µs. |
+| 6                   | 127 ms        | 115.58µs. | 2.15ms.   |
+| 7                   | 160 ms        | 4.82ms.   | 115.70ms. |

--- a/benches/src/engine/infino.rs
+++ b/benches/src/engine/infino.rs
@@ -55,15 +55,28 @@ impl InfinoEngine {
     println!("Infino time required for insertion: {:.2?}", elapsed);
   }
 
-  pub fn search(self, query: &str, range_start_time: u64, range_end_time: u64) -> usize {
+  pub fn search(&self, query: &str, range_start_time: u64, range_end_time: u64) -> usize {
+    let num_words = query.split_whitespace().count();
     let now = Instant::now();
     let result = self.tsldb.search(query, range_start_time, range_end_time);
     let elapsed = now.elapsed();
-    println!("Infino time required for search: {:.2?}", elapsed);
+    println!(
+      "Infino time required for searching {} word query is : {:.2?}. Num of results {}",
+      num_words,
+      elapsed,
+      result.len()
+    );
     return result.len();
   }
 
   pub fn get_index_dir_path(&self) -> &str {
     self.index_dir_path.as_str()
+  }
+
+  pub fn search_multiple_queries(&self, queries: &[&str]) -> usize {
+    queries
+      .iter()
+      .map(|query| self.search(query, 0, u64::MAX))
+      .count()
   }
 }

--- a/benches/src/engine/tantivy.rs
+++ b/benches/src/engine/tantivy.rs
@@ -60,7 +60,8 @@ impl Tantivy {
   }
 
   // Searches the document against the query and returns the count of of matching document
-  pub fn search(self, query: &str) -> usize {
+  pub fn search(&self, query: &str) -> usize {
+    let num_words = query.split_whitespace().count();
     let reader = self
       .index
       .reader_builder()
@@ -77,7 +78,16 @@ impl Tantivy {
       .search(&query, &TopDocs::with_limit(100_000))
       .unwrap();
     let elapsed = now.elapsed();
-    println!("Tantivy time required for search: {:.2?}", elapsed);
+    println!(
+      "Tantivy time required for searching {} word query is : {:.2?}. Num of results {}",
+      num_words,
+      elapsed,
+      top_docs.len()
+    );
     return top_docs.len();
+  }
+
+  pub fn search_multiple_queries(&self, queries: &[&str]) -> usize {
+    queries.iter().map(|query| self.search(query)).count()
   }
 }


### PR DESCRIPTION

## What does this PR do?
- Bulk insert for elasticsearch and some benchmark numbers updated in README

Need to figure out some issue with ES returning 10k records for some of the searches. Check the run log

```
➜  ~/Desktop/code/tsldb/infino/benches git:(main) ✗ cargo run -r
   Compiling benches v0.1.0 (/Users/savannahar/Desktop/code/tsldb/infino/benches)
    Finished release [optimized] target(s) in 4.51s
     Running `target/release/benches`
Infino time required for insertion: 315.23ms
Output of ls on tantivy index directory Output { status: ExitStatus(unix_wait_status(0)), stdout: "total 16\n0 0\n8 all_segments_list.bin\n8 metadata.bin\n\nindex/0:\ntotal 3672\n1840 forward_map.bin\n1392 inverted_map.bin\n   8 labels.bin\n   8 metadata.bin\n 416 terms.bin\n   8 time_series.bin\n", stderr: "" }
Infino index size = 1860422 bytes
Infino time required for searching 1 word query is : 1.48ms. Num of results 6837
Infino time required for searching 2 word query is : 17.75µs. Num of results 45
Infino time required for searching 3 word query is : 144.71ms. Num of results 46
Infino time required for searching 4 word query is : 37.33ms. Num of results 5708
Infino time required for searching 5 word query is : 234.08µs. Num of results 1
Infino time required for searching 6 word query is : 2.15ms. Num of results 2
Infino time required for searching 7 word query is : 115.70ms. Num of results 4478
Tantivy time required for insertion: 1.95s
Output of ls on tantivy index directory Output { status: ExitStatus(unix_wait_status(0)), stdout: "total 7144\n  8 4f0e1d0f780740e2abd30b56bad71538.fast\n  8 4f0e1d0f780740e2abd30b56bad71538.fieldnorm\n152 4f0e1d0f780740e2abd30b56bad71538.idx\n 80 4f0e1d0f780740e2abd30b56bad71538.pos\n144 4f0e1d0f780740e2abd30b56bad71538.store\n 24 4f0e1d0f780740e2abd30b56bad71538.term\n  8 52bfffaa875e475f86d9dc0b3b289484.fast\n 24 52bfffaa875e475f86d9dc0b3b289484.fieldnorm\n384 52bfffaa875e475f86d9dc0b3b289484.idx\n184 52bfffaa875e475f86d9dc0b3b289484.pos\n496 52bfffaa875e475f86d9dc0b3b289484.store\n 40 52bfffaa875e475f86d9dc0b3b289484.term\n  8 56b3a300084d40c19db59f2ece4d4cd7.fast\n 16 56b3a300084d40c19db59f2ece4d4cd7.fieldnorm\n296 56b3a300084d40c19db59f2ece4d4cd7.idx\n144 56b3a300084d40c19db59f2ece4d4cd7.pos\n392 56b3a300084d40c19db59f2ece4d4cd7.store\n 32 56b3a300084d40c19db59f2ece4d4cd7.term\n  8 6c05d049c984409fbac07e48b0bb1380.fast\n  8 6c05d049c984409fbac07e48b0bb1380.fieldnorm\n168 6c05d049c984409fbac07e48b0bb1380.idx\n 88 6c05d049c984409fbac07e48b0bb1380.pos\n136 6c05d049c984409fbac07e48b0bb1380.store\n 16 6c05d049c984409fbac07e48b0bb1380.term\n  8 733742d82e3248f99294b9f258d8a558.fast\n 16 733742d82e3248f99294b9f258d8a558.fieldnorm\n232 733742d82e3248f99294b9f258d8a558.idx\n112 733742d82e3248f99294b9f258d8a558.pos\n344 733742d82e3248f99294b9f258d8a558.store\n 32 733742d82e3248f99294b9f258d8a558.term\n  8 7b5a7872af3b48ec95c7febfcfb755db.fast\n 24 7b5a7872af3b48ec95c7febfcfb755db.fieldnorm\n416 7b5a7872af3b48ec95c7febfcfb755db.idx\n200 7b5a7872af3b48ec95c7febfcfb755db.pos\n528 7b5a7872af3b48ec95c7febfcfb755db.store\n 40 7b5a7872af3b48ec95c7febfcfb755db.term\n  0 a54d47ba33694e358a2ccae4c431250f.fast\n  0 a54d47ba33694e358a2ccae4c431250f.store\n  8 bf5bc18b0e734f449f78e2674cd31127.fast\n 24 bf5bc18b0e734f449f78e2674cd31127.fieldnorm\n616 bf5bc18b0e734f449f78e2674cd31127.idx\n240 bf5bc18b0e734f449f78e2674cd31127.pos\n600 bf5bc18b0e734f449f78e2674cd31127.store\n 40 bf5bc18b0e734f449f78e2674cd31127.term\n  8 c0889ff04eb94122949ebb312b2a7383.fast\n 16 c0889ff04eb94122949ebb312b2a7383.fieldnorm\n248 c0889ff04eb94122949ebb312b2a7383.idx\n128 c0889ff04eb94122949ebb312b2a7383.pos\n352 c0889ff04eb94122949ebb312b2a7383.store\n 32 c0889ff04eb94122949ebb312b2a7383.term\n  8 meta.json\n", stderr: "" }
Tantivy index size with STORED flag = 3122681 bytes
Tantivy time required for searching 1 word query is : 2.85ms. Num of results 6838
Tantivy time required for searching 2 word query is : 88.29µs. Num of results 45
Tantivy time required for searching 3 word query is : 2.54ms. Num of results 46
Tantivy time required for searching 4 word query is : 3.99ms. Num of results 5708
Tantivy time required for searching 5 word query is : 156.79µs. Num of results 1
Tantivy time required for searching 6 word query is : 115.58µs. Num of results 2
Tantivy time required for searching 7 word query is : 4.82ms. Num of results 7779
Index perftest already exists. Now deleting it.
Elasticsearch time required for insertion: 2.22s
#56482 Response { method: Post, url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("localhost")), port: Some(9200), path: "/perftest/_bulk", query: None, fragment: None }, status_code: 200, headers: {"x-elastic-product": "Elasticsearch", "content-type": "application/json; charset=UTF-8", "transfer-encoding": "chunked"} }
Elasticsearch index size in the following statement: [{"health":"green","status":"open","index":"perftest","uuid":"fvJ17Ld4TrizHOrN6jYCtw","pri":"1","rep":"0","docs.count":"56482","docs.deleted":"0","store.size":"2.4mb","pri.store.size":"2.4mb"}]
Elasticsearch time required for searching 1 word query is : 169 ms . Num of results 6838
Elasticsearch time required for searching 2 word query is : 7 ms . Num of results 90
Elasticsearch time required for searching 3 word query is : 145 ms . Num of results 10000
Elasticsearch time required for searching 4 word query is : 155 ms . Num of results 10000
Elasticsearch time required for searching 5 word query is : 135 ms . Num of results 10000
Elasticsearch time required for searching 6 word query is : 127 ms . Num of results 10000
Elasticsearch time required for searching 7 word query is : 160 ms . Num of results 10000
```