### PR TITLE
Make the rabbitmq queue optional - controlled by config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ features = [
 [dev-dependencies]
 tower = { version = "*", features = ["util"] }
 tempdir = "*"
+test-case = "*"
 urlencoding = "*"
 
 [profile.release]

--- a/config/default.toml
+++ b/config/default.toml
@@ -8,7 +8,11 @@ port = 3000
 commit_interval_in_seconds = 30
 timestamp_key = "date"
 labels_key = "labels"
+use_rabbitmq = "no"             # specifies whether to write incoming messages to rabbitmq
 
+
+# In case the server section specifies to use rabbitmq (use_rabbitmq = yes),
+# configuration for rabbitmq needs to be specified. Sample configuration below.
 [rabbitmq]
 container_name = "infino-queue"
 stream_port = 5552

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -11,6 +11,7 @@ pub struct ServerSettings {
   port: u16,
   timestamp_key: String,
   labels_key: String,
+  use_rabbitmq: bool,
 }
 
 impl ServerSettings {
@@ -32,6 +33,11 @@ impl ServerSettings {
   /// Get the labels for timestamp in json.
   pub fn get_labels_key(&self) -> &str {
     &self.labels_key
+  }
+
+  /// Get the flag to decide whether to use rabbitmq.
+  pub fn get_use_rabbitmq(&self) -> bool {
+    self.use_rabbitmq
   }
 }
 
@@ -64,7 +70,7 @@ impl RabbitMQSettings {
 /// Settings for Tsldb, read from config file.
 pub struct Settings {
   server: ServerSettings,
-  rabbitmq: RabbitMQSettings,
+  rabbitmq: Option<RabbitMQSettings>,
 }
 
 impl Settings {
@@ -96,7 +102,12 @@ impl Settings {
 
   /// Get tsldb settings.
   pub fn get_rabbitmq_settings(&self) -> &RabbitMQSettings {
-    &self.rabbitmq
+    let rabbitmq_settings = self
+      .rabbitmq
+      .as_ref()
+      .expect("Could not retrieve rabbitmq settings");
+
+    &rabbitmq_settings
   }
 
   #[cfg(test)]
@@ -113,7 +124,7 @@ mod tests {
   #[test]
   fn test_settings() {
     let config_dir_path = "config";
-    let settings = Settings::new(&config_dir_path).unwrap();
+    let settings = Settings::new(&config_dir_path).expect("Could not parse config");
 
     // Check server settings.
     let server_settings = settings.get_server_settings();


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
- Make the rabbitmq queue optional - controlled by config.
 
## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
