### PR TITLE
Add flush api to forcibly flush the index - useful in performance tests

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -6,19 +6,19 @@ edition = "2021"
 [dependencies]
 chrono = "*"
 clickhouse = "*"
-elasticsearch = "8.5.0-alpha.1"
+elasticsearch = "8.7.0-alpha.1"
 fs_extra = "1.2.0"
 serde = { version = "~1", features = ["derive"]}
 serde_json = "~1"
 tokio = { version = "*", features = ["full"] }
 url = "2.3.1"
 uuid = "1.2.2"
-tantivy = "0.19.2"
+tantivy = "0.21.0"
 tempfile = "*"
 tempdir = "*"
-prometheus = "0.10.0"
+prometheus = "0.13.3"
 warp = "*"
-sysinfo = "0.17.3"
+sysinfo = "0.29.10"
 reqwest = "0.11.17"
 
 [dependencies.tsldb]

--- a/tsldb/src/lib.rs
+++ b/tsldb/src/lib.rs
@@ -89,6 +89,8 @@ impl Tsldb {
   }
 
   /// Commit the index.
+  /// If the flag sync_after_commit is set to true, the directory is sync-ed immediately instead of relying on the OS to do so,
+  /// hence this flag is usually set to true only in tests.
   pub fn commit(&self, sync_after_commit: bool) {
     self.index.commit(sync_after_commit);
   }


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Add flush api to forcibly flush the index - useful in performance tests

## How does this PR work? (optional)
- Added flush as a top-level API, which calls tsldb's commit with sync_after_commit flag set to true. That way, the index is forcibly flushed to disk.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
