### PR TITLE
Split logs with unicode support, along with a special FIELD_DELIMITER

### DIFF
--- a/tsldb/Cargo.toml
+++ b/tsldb/Cargo.toml
@@ -15,7 +15,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1"
 tsz = "0.1.4"
-zstd = "0.12"
+unicode-segmentation = "1.10.1"
+zstd = "0.13.0"
 
 [dev-dependencies]
 env_logger = "*"
@@ -33,4 +34,4 @@ features = [
 ]
 
 [target.'cfg(loom)'.dependencies]
-loom = { version = "0.5.6" }
+loom = { version = "0.7.1" }

--- a/tsldb/src/log/log_message.rs
+++ b/tsldb/src/log/log_message.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::utils::tokenize::tokenize;
+use crate::utils::tokenize::FIELD_DELIMITER;
 
 /// Struct to represent a log message with timestamp.
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -68,7 +69,7 @@ impl LogMessage {
       let name = field.0;
       let values = Vec::from_iter(field.1.split_whitespace());
       for value in values {
-        let term = format!("{}:{}", name, value);
+        let term = format!("{}{}{}", name, FIELD_DELIMITER, value);
         terms.push(term);
       }
     }
@@ -129,7 +130,7 @@ mod tests {
     assert_eq!(terms.len(), 4);
     assert!(terms.contains(&"mytext1".to_owned()));
     assert!(terms.contains(&"mytext2".to_owned()));
-    assert!(terms.contains(&"field1:value1".to_owned()));
-    assert!(terms.contains(&"field2:value2".to_owned()));
+    assert!(terms.contains(&format!("field1{}value1", FIELD_DELIMITER)));
+    assert!(terms.contains(&format!("field2{}value2", FIELD_DELIMITER)));
   }
 }

--- a/tsldb/src/log/log_message.rs
+++ b/tsldb/src/log/log_message.rs
@@ -60,14 +60,12 @@ impl LogMessage {
 
     // Each word in text goes as it is in terms.
     let tokens = tokenize(&text_lower);
-    for token in tokens {
-      terms.push(token.to_owned());
-    }
+    terms.extend(tokens);
 
     // Each word in a field value goes with a perfix a of its field name, followed by ":".
     for field in &self.fields {
       let name = field.0;
-      let values = Vec::from_iter(field.1.split_whitespace());
+      let values = tokenize(field.1);
       for value in values {
         let term = format!("{}{}{}", name, FIELD_DELIMITER, value);
         terms.push(term);

--- a/tsldb/src/log/log_message.rs
+++ b/tsldb/src/log/log_message.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+use crate::utils::tokenize::tokenize;
+
 /// Struct to represent a log message with timestamp.
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct LogMessage {
@@ -53,12 +55,13 @@ impl LogMessage {
   /// Get the terms corresponding to this log message.
   pub fn get_terms(&self) -> Vec<String> {
     let text_lower = self.text.to_lowercase();
+    let mut terms: Vec<String> = Vec::new();
 
     // Each word in text goes as it is in terms.
-    let mut terms: Vec<String> = text_lower
-      .split_whitespace()
-      .map(|s| s.to_owned())
-      .collect();
+    let tokens = tokenize(&text_lower);
+    for token in tokens {
+      terms.push(token.to_owned());
+    }
 
     // Each word in a field value goes with a perfix a of its field name, followed by ":".
     for field in &self.fields {

--- a/tsldb/src/segment_manager/segment.rs
+++ b/tsldb/src/segment_manager/segment.rs
@@ -14,6 +14,7 @@ use crate::utils::range::is_overlap;
 use crate::utils::serialize;
 use crate::utils::sync::thread;
 use crate::utils::sync::Mutex;
+use crate::utils::tokenize::tokenize;
 
 use super::metadata::Metadata;
 
@@ -304,7 +305,7 @@ impl Segment {
     // TODO: make the implementation below more performant by using the skip pointers (aka initial values)
     // and not decompressing every block in every postings list.
     let query_lowercase = query.to_lowercase();
-    let terms = query_lowercase.split_whitespace();
+    let terms = tokenize(&query_lowercase);
     let mut postings_lists: Vec<Vec<u32>> = Vec::new();
 
     for term in terms {

--- a/tsldb/src/segment_manager/segment.rs
+++ b/tsldb/src/segment_manager/segment.rs
@@ -309,7 +309,7 @@ impl Segment {
     let mut postings_lists: Vec<Vec<u32>> = Vec::new();
 
     for term in terms {
-      let result = self.terms.get(term);
+      let result = self.terms.get(&term);
       let term_id: u32 = match result {
         Some(result) => *result,
         None => {
@@ -439,6 +439,7 @@ mod tests {
   use super::*;
   use crate::utils::sync::is_sync;
   use crate::utils::sync::thread;
+  use crate::utils::tokenize::FIELD_DELIMITER;
 
   #[test]
   fn test_new_segment() {
@@ -486,7 +487,9 @@ mod tests {
     assert!(segment.terms.contains_key("blah"));
     assert!(segment.terms.contains_key("log"));
     assert!(segment.terms.contains_key("1st"));
-    assert!(segment.terms.contains_key("key1:val1"));
+    assert!(segment
+      .terms
+      .contains_key(&format!("key1{}val1", FIELD_DELIMITER)));
 
     // Test search.
     let mut results = segment.search("this", 0, u64::MAX);
@@ -505,7 +508,7 @@ mod tests {
     assert!(results.len() == 1);
     assert_eq!(results.get(0).unwrap().get_text(), "blah");
 
-    results = segment.search("key1:val1", start, end);
+    results = segment.search(&format!("key1{}val1", FIELD_DELIMITER), start, end);
     assert!(results.len() == 1);
     assert_eq!(results.get(0).unwrap().get_text(), "blah");
 
@@ -529,7 +532,7 @@ mod tests {
     results = segment.search("1st log message", start, end);
     assert_eq!(results.len(), 1);
 
-    results = segment.search("blah key1:val1", start, end);
+    results = segment.search(&format!("blah key1{}val1", FIELD_DELIMITER), start, end);
     assert_eq!(results.len(), 1);
 
     // Test with ranges that do not exist in the index.

--- a/tsldb/src/utils/mod.rs
+++ b/tsldb/src/utils/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod custom_serde;
 pub(crate) mod error;
 pub(crate) mod range;
 pub(crate) mod serialize;
+pub(crate) mod tokenize;
 
 pub mod config;
 pub mod io;

--- a/tsldb/src/utils/tokenize.rs
+++ b/tsldb/src/utils/tokenize.rs
@@ -1,0 +1,30 @@
+use unicode_segmentation::UnicodeSegmentation;
+
+pub fn tokenize(input: &str) -> Vec<&str> {
+  let words = input.unicode_words().collect::<Vec<&str>>();
+
+  words
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_tokenize() {
+    let words = tokenize("a quick brown");
+    assert_eq!(words, vec!["a", "quick", "brown"]);
+
+    let words = tokenize("[notice]: this is last boarding call.");
+    assert_eq!(
+      words,
+      vec!["notice", "this", "is", "last", "boarding", "call"]
+    );
+
+    let words = tokenize("He said, \"Hi, there!\"");
+    assert_eq!(words, vec!["He", "said", "Hi", "there"]);
+
+    let words = tokenize("sky:1 test:2 test:345");
+    assert_eq!(words, vec!["sky:1", "test:2", "test:345"]);
+  }
+}

--- a/tsldb/src/utils/tokenize.rs
+++ b/tsldb/src/utils/tokenize.rs
@@ -1,9 +1,31 @@
 use unicode_segmentation::UnicodeSegmentation;
 
-pub fn tokenize(input: &str) -> Vec<&str> {
-  let words = input.unicode_words().collect::<Vec<&str>>();
+pub const FIELD_DELIMITER: char = '~';
 
-  words
+// Tokenize a given string. Note that FIELD_DELIMITER is a special character that we use a field sepator in queries, and so we do not tokenize on "~".
+pub fn tokenize(input: &str) -> Vec<String> {
+  // First, create different segments based on FIELD_DELIMITER separator.
+  let segments: Vec<&str> = input.split(FIELD_DELIMITER).collect();
+
+  let mut tokens: Vec<String> = Vec::new();
+  for segment in segments {
+    // Unicode tokenize each segment.
+    let words: Vec<&str> = segment.unicode_words().collect();
+
+    // Merge each segment, making sure to add the special delimiter FIELD_DELIMITER back at the end of each segment.
+    // As an example, if the first segment is vec!["a", "b"], and the next segment is vec!["c", "d"], and the
+    // field delimiter is "~", the tokens will be vec!["a", "b~c", "d"]
+    for (pos, word) in words.iter().enumerate() {
+      if pos == 0 && tokens.len() > 0 {
+        let word_with_tilde = format!("{}{}", FIELD_DELIMITER, word);
+        tokens.last_mut().unwrap().push_str(&word_with_tilde);
+      } else {
+        tokens.push(word.to_string());
+      }
+    }
+  }
+
+  tokens
 }
 
 #[cfg(test)]
@@ -12,8 +34,11 @@ mod tests {
 
   #[test]
   fn test_tokenize() {
-    let words = tokenize("a quick brown");
-    assert_eq!(words, vec!["a", "quick", "brown"]);
+    let words = tokenize("a quick brown fox jumped 5.2 feet");
+    assert_eq!(
+      words,
+      vec!["a", "quick", "brown", "fox", "jumped", "5.2", "feet"]
+    );
 
     let words = tokenize("[notice]: this is last boarding call.");
     assert_eq!(
@@ -24,7 +49,35 @@ mod tests {
     let words = tokenize("He said, \"Hi, there!\"");
     assert_eq!(words, vec!["He", "said", "Hi", "there"]);
 
-    let words = tokenize("sky:1 test:2 test:345");
-    assert_eq!(words, vec!["sky:1", "test:2", "test:345"]);
+    // "~" appearing at the beginning of the text does get treated a seperator,
+    // while the one appearing in between doesn't.
+    let words = tokenize(&format!(
+      "~sky:1 test{}2 thisisaword test{}345",
+      FIELD_DELIMITER, FIELD_DELIMITER
+    ));
+    assert_eq!(
+      words,
+      vec![
+        "sky",
+        "1",
+        &format!("test{}2", FIELD_DELIMITER),
+        "thisisaword",
+        &format!("test{}345", FIELD_DELIMITER)
+      ]
+    );
+
+    let words = tokenize(&format!(
+      "sky:1 test{}2 test{}345",
+      FIELD_DELIMITER, FIELD_DELIMITER
+    ));
+    assert_eq!(
+      words,
+      vec![
+        "sky",
+        "1",
+        &format!("test{}2", FIELD_DELIMITER),
+        &format!("test{}345", FIELD_DELIMITER)
+      ]
+    );
   }
 }


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Split logs with unicode support, along with a special FIELD_DELIMITER
