### PR TITLE
chore: fix tests failing because of config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -721,7 +721,7 @@ mod tests {
 
     create_test_config(
       config_dir_path,
-      &index_dir_path,
+      index_dir_path,
       container_name,
       use_rabbitmq,
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -721,7 +721,7 @@ mod tests {
 
     create_test_config(
       config_dir_path,
-      index_dir_path,
+      &index_dir_path,
       container_name,
       use_rabbitmq,
     );

--- a/tsldb/src/lib.rs
+++ b/tsldb/src/lib.rs
@@ -287,8 +287,8 @@ mod tests {
     let config_dir = TempDir::new("config_test").unwrap();
     let config_dir_path = config_dir.path().to_str().unwrap();
     let index_dir = TempDir::new("index_test").unwrap();
-    let index_dir_path = format!("{}/data", index_dir.path().to_str().unwrap());
-    create_test_config(config_dir_path, &index_dir_path);
+    let index_dir_path = index_dir.path().to_str().unwrap();
+    create_test_config(config_dir_path, index_dir_path);
     println!("Config dir path {}", config_dir_path);
 
     // Create a new tsldb instance.


### PR DESCRIPTION
Fix failing tests

## What does this PR do?
- If index directory already exist without any index it in, then the tests will fail. So check for existing indexes, if not available then create default
