### PR TITLE
Fix link to the "Python Client" example. Fixes issue #142

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@
 ![Elastic Logo](docs/images/ElasticLicenseLogo.svg)
 [![Github Commits](https://img.shields.io/github/commit-activity/m/infinohq/infino)](https://github.com/infinohq/infino/commits)
 <a href="https://github.com/infinohq/infino/actions/workflows/post-merge-ci.yml">
-  <img src="https://github.com/infinohq/infino/actions/workflows/post-merge-ci.yml/badge.svg?branch=main" alt="Status" >
+<img src="https://github.com/infinohq/infino/actions/workflows/post-merge-ci.yml/badge.svg?branch=main" alt="Status" >
 </a>
 [![Join Slack](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://infinohq.slack.com/join/shared_invite/zt-1tqqc0vsz-jF80cpkGy7aFsALQKggy8g#/shared-invite/email)
-
 
 [Report Bug](https://github.com/infinohq/infino/issues/new?assignees=&labels=&template=bug_report.md) |
 [Request Feature](https://github.com/infinohq/infino/issues/new?assignees=&labels=&template=feature_request.md)
@@ -21,9 +20,11 @@
 Infino is a scalable telemetry store designed for logs, metrics, and traces. Infino can function as a standalone observability solution or as the storage layer in your observability stack.
 
 ## Why Infino?
-Telemetry data volumes are increasing exponentially yet there is no  purpose-built storage platform for telemetry. Most observability stacks are built on [ElasticSearch](https://github.com/elastic/elasticsearch-rs), [Clickhouse](https://github.com/ClickHouse/ClickHouse) or [Prometheus](https://github.com/prometheus/prometheus), which are powerful tools but are not built for modern telemetry data so the stacks become complex and expensive to manage. Infino's goal is to reduce the **cost** and **complexity** of observability with smart, high-performance storage for customers and vendors alike.
+
+Telemetry data volumes are increasing exponentially yet there is no purpose-built storage platform for telemetry. Most observability stacks are built on [ElasticSearch](https://github.com/elastic/elasticsearch-rs), [Clickhouse](https://github.com/ClickHouse/ClickHouse) or [Prometheus](https://github.com/prometheus/prometheus), which are powerful tools but are not built for modern telemetry data so the stacks become complex and expensive to manage. Infino's goal is to reduce the **cost** and **complexity** of observability with smart, high-performance storage for customers and vendors alike.
 
 ## How it works
+
 To address **cost**, Infino focuses on performance ([**see benchmarks here**](benches/README.md)):
 
 - **Index:** Append-only inverted index (more performant on telemetry data than general-purpose indexes like Lucene).
@@ -40,21 +41,24 @@ To address **complexity**, Infino focuses on AI and automation:
 ![Architecture (Light)](docs/images/Infino_architecture_light.png#gh-light-mode-only)
 ![Architecture (Dark)](docs/images/Infino_architecture_dark.png#gh-dark-mode-only)
 
-
 ## Developer Docs
+
 Read our repo documentation [here](https://infinohq.github.io/infino/doc/infino/index.html).
 
 ## Features
-Note that we are still very much an alpha product but we have lots on the roadmap. Our development at the moment is focused on increasing the performance of the core engine to address **cost** but we are starting to add features to address **complexity**. 
+
+Note that we are still very much an alpha product but we have lots on the roadmap. Our development at the moment is focused on increasing the performance of the core engine to address **cost** but we are starting to add features to address **complexity**.
 
 #### Available now
- - Store logs and metrics
- - Ingest using [FluentBit](https://fluentbit.io/)
- - Query logs and metrics
- - Python client
- - LLM monitoring using [Langchain](https://github.com/langchain-ai/langchain)
+
+- Store logs and metrics
+- Ingest using [FluentBit](https://fluentbit.io/)
+- Query logs and metrics
+- Python client
+- LLM monitoring using [Langchain](https://github.com/langchain-ai/langchain)
 
 #### Coming soon
+
 - Dashboards
 - SQL
 - NLP
@@ -64,18 +68,18 @@ Note that we are still very much an alpha product but we have lots on the roadma
 ## Getting started
 
 ### Try it
+
 For now, you need to build the repo. You will first need to:
 
 - Install [Docker](https://docs.docker.com/engine/install/).
 - Install [Rust toolchain](https://www.rust-lang.org/tools/install).
 
-
 ### Examples
 
-* [Integration with Fluentbit](examples/fluentbit/README.md) - Learn how to publish telemetry to Infino using FluentBit.
-* [LLM monitoring with Langchain](examples/llm-monitoring-langchain/llm-monitoring-langchain.ipynb) - Discover how Infino's callback in Langchain can be used for monitoring requests in real-time. Also checkout the [Langchain <> Infino docs](https://python.langchain.com/docs/ecosystem/integrations/infino).
-* [LLM monitoring with OpenAI](examples/llm-monitoring-openai/llm-monitoring-openai.ipynb) - See an example of monitoring OpenAI's services.
-* [Using Infino's Python client](https://pyup.io/packages/pypi/infinopy/) - Get started with the Python client for Infino and explore its functionalities.
+- [Integration with Fluentbit](examples/fluentbit/README.md) - Learn how to publish telemetry to Infino using FluentBit.
+- [LLM monitoring with Langchain](examples/llm-monitoring-langchain/llm-monitoring-langchain.ipynb) - Discover how Infino's callback in Langchain can be used for monitoring requests in real-time. Also checkout the [Langchain <> Infino docs](https://python.langchain.com/docs/ecosystem/integrations/infino).
+- [LLM monitoring with OpenAI](examples/llm-monitoring-openai/llm-monitoring-openai.ipynb) - See an example of monitoring OpenAI's services.
+- [Using Infino's Python client](examples/python-client/rally-tracks.ipynb) - Get started with the [Python client](https://pyup.io/packages/pypi/infinopy/) for Infino and explore its functionalities.
 
 </br>
 
@@ -99,4 +103,5 @@ A big thank you to the community for making Infino possible!
 </a>
 
 ## License
+
 Infino is distributed under the Elastic 2.0 license.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 ![Elastic Logo](docs/images/ElasticLicenseLogo.svg)
 [![Github Commits](https://img.shields.io/github/commit-activity/m/infinohq/infino)](https://github.com/infinohq/infino/commits)
 <a href="https://github.com/infinohq/infino/actions/workflows/post-merge-ci.yml">
-<img src="https://github.com/infinohq/infino/actions/workflows/post-merge-ci.yml/badge.svg?branch=main" alt="Status" >
+  <img src="https://github.com/infinohq/infino/actions/workflows/post-merge-ci.yml/badge.svg?branch=main" alt="Status" >
 </a>
 [![Join Slack](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://infinohq.slack.com/join/shared_invite/zt-1tqqc0vsz-jF80cpkGy7aFsALQKggy8g#/shared-invite/email)
+
 
 [Report Bug](https://github.com/infinohq/infino/issues/new?assignees=&labels=&template=bug_report.md) |
 [Request Feature](https://github.com/infinohq/infino/issues/new?assignees=&labels=&template=feature_request.md)
@@ -20,11 +21,9 @@
 Infino is a scalable telemetry store designed for logs, metrics, and traces. Infino can function as a standalone observability solution or as the storage layer in your observability stack.
 
 ## Why Infino?
-
-Telemetry data volumes are increasing exponentially yet there is no purpose-built storage platform for telemetry. Most observability stacks are built on [ElasticSearch](https://github.com/elastic/elasticsearch-rs), [Clickhouse](https://github.com/ClickHouse/ClickHouse) or [Prometheus](https://github.com/prometheus/prometheus), which are powerful tools but are not built for modern telemetry data so the stacks become complex and expensive to manage. Infino's goal is to reduce the **cost** and **complexity** of observability with smart, high-performance storage for customers and vendors alike.
+Telemetry data volumes are increasing exponentially yet there is no  purpose-built storage platform for telemetry. Most observability stacks are built on [ElasticSearch](https://github.com/elastic/elasticsearch-rs), [Clickhouse](https://github.com/ClickHouse/ClickHouse) or [Prometheus](https://github.com/prometheus/prometheus), which are powerful tools but are not built for modern telemetry data so the stacks become complex and expensive to manage. Infino's goal is to reduce the **cost** and **complexity** of observability with smart, high-performance storage for customers and vendors alike.
 
 ## How it works
-
 To address **cost**, Infino focuses on performance ([**see benchmarks here**](benches/README.md)):
 
 - **Index:** Append-only inverted index (more performant on telemetry data than general-purpose indexes like Lucene).
@@ -41,24 +40,21 @@ To address **complexity**, Infino focuses on AI and automation:
 ![Architecture (Light)](docs/images/Infino_architecture_light.png#gh-light-mode-only)
 ![Architecture (Dark)](docs/images/Infino_architecture_dark.png#gh-dark-mode-only)
 
-## Developer Docs
 
+## Developer Docs
 Read our repo documentation [here](https://infinohq.github.io/infino/doc/infino/index.html).
 
 ## Features
-
-Note that we are still very much an alpha product but we have lots on the roadmap. Our development at the moment is focused on increasing the performance of the core engine to address **cost** but we are starting to add features to address **complexity**.
+Note that we are still very much an alpha product but we have lots on the roadmap. Our development at the moment is focused on increasing the performance of the core engine to address **cost** but we are starting to add features to address **complexity**. 
 
 #### Available now
-
-- Store logs and metrics
-- Ingest using [FluentBit](https://fluentbit.io/)
-- Query logs and metrics
-- Python client
-- LLM monitoring using [Langchain](https://github.com/langchain-ai/langchain)
+ - Store logs and metrics
+ - Ingest using [FluentBit](https://fluentbit.io/)
+ - Query logs and metrics
+ - Python client
+ - LLM monitoring using [Langchain](https://github.com/langchain-ai/langchain)
 
 #### Coming soon
-
 - Dashboards
 - SQL
 - NLP
@@ -68,18 +64,18 @@ Note that we are still very much an alpha product but we have lots on the roadma
 ## Getting started
 
 ### Try it
-
 For now, you need to build the repo. You will first need to:
 
 - Install [Docker](https://docs.docker.com/engine/install/).
 - Install [Rust toolchain](https://www.rust-lang.org/tools/install).
 
+
 ### Examples
 
-- [Integration with Fluentbit](examples/fluentbit/README.md) - Learn how to publish telemetry to Infino using FluentBit.
-- [LLM monitoring with Langchain](examples/llm-monitoring-langchain/llm-monitoring-langchain.ipynb) - Discover how Infino's callback in Langchain can be used for monitoring requests in real-time. Also checkout the [Langchain <> Infino docs](https://python.langchain.com/docs/ecosystem/integrations/infino).
-- [LLM monitoring with OpenAI](examples/llm-monitoring-openai/llm-monitoring-openai.ipynb) - See an example of monitoring OpenAI's services.
-- [Using Infino's Python client](examples/python-client/rally-tracks.ipynb) - Get started with the [Python client](https://pyup.io/packages/pypi/infinopy/) for Infino and explore its functionalities.
+* [Integration with Fluentbit](examples/fluentbit/README.md) - Learn how to publish telemetry to Infino using FluentBit.
+* [LLM monitoring with Langchain](examples/llm-monitoring-langchain/llm-monitoring-langchain.ipynb) - Discover how Infino's callback in Langchain can be used for monitoring requests in real-time. Also checkout the [Langchain <> Infino docs](https://python.langchain.com/docs/ecosystem/integrations/infino).
+* [LLM monitoring with OpenAI](examples/llm-monitoring-openai/llm-monitoring-openai.ipynb) - See an example of monitoring OpenAI's services.
+* [Using Infino's Python client](examples/python-client/rally-tracks.ipynb) - Get started with the [Python client](https://pyup.io/packages/pypi/infinopy/) for Infino and explore its functionalities.
 
 </br>
 
@@ -103,5 +99,4 @@ A big thank you to the community for making Infino possible!
 </a>
 
 ## License
-
 Infino is distributed under the Elastic 2.0 license.


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
- Fixes issue #142 → Link to python client example in the Examples section of readme is pointing to the python package instead of the jupyter notebook.
- Fix updates the link to point to [examples/python-client/rally-tracks.ipynb](https://github.com/infinohq/infino/blob/main/examples/python-client/rally-tracks.ipynb).

## How does this PR work? (optional)
- Need a brief introduction for the changed logic (optional)

## Refer to a related PR or issue link
- #142 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
