### PR TITLE
chore: fix for multi segment search edge case

### DIFF
--- a/coredb/src/index_manager/index.rs
+++ b/coredb/src/index_manager/index.rs
@@ -841,6 +841,13 @@ mod tests {
       let results = index.search_logs(suffix, start_time, end_time);
       assert_eq!(results.len(), 1);
     }
+
+    // Make sure that the prefix+suffix is in exactly one log message.
+    for i in 1..num_log_messages {
+      let message = &format!("{} {}", message_prefix, i);
+      let results = index.search_logs(message, start_time, end_time);
+      assert_eq!(results.len(), 1);
+    }
   }
 
   #[test]

--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -498,8 +498,10 @@ impl Segment {
         if acc_index < accumulator.len() && accumulator[acc_index] > initial_values[initial_index] {
           // If current accumulator element is in between current initial_value and next initial_value
           // then check the existing posting block for matches with accumlator
-          if initial_index + 1 < initial_values.len()
-            && accumulator[acc_index] < initial_values[initial_index + 1]
+          // OR if it's the last accumulator is greater than last initial value, then check the last posting block
+          if (initial_index + 1 < initial_values.len()
+            && accumulator[acc_index] < initial_values[initial_index + 1])
+            || (initial_index == initial_values.len() - 1)
           {
             let mut _posting_block = Vec::new();
             // posting_index == posting_list.len() means that we are at last_block


### PR DESCRIPTION
## What does this PR do?
- Bug fix for multi segment search where accumulator has data greater than last initial index element, and there was a miss to check last posting block in such cases 

## How does this PR work? (optional)
- Fix for search

## Refer to a related PR or issue link
- Raised in #possible-bug-log

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
