### PR TITLE
Refactor segment_manager.search_logs to be a bit easier to read.

### DIFF
--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -388,7 +388,7 @@ impl Segment {
         Some(result) => *result,
         None => {
           // Term not found.
-          return; // is this right?
+          return;
         }
       };
       let postings_list = match self.inverted_map.get(&term_id) {
@@ -613,7 +613,6 @@ impl Segment {
     range_start_time: u64,
     range_end_time: u64,
   ) -> Vec<LogMessage> {
-    // TODO: make the implementation below more performant by not decompressing every block in every postings list.
     let query_lowercase = query.to_lowercase();
     let terms = tokenize(&query_lowercase);
 


### PR DESCRIPTION
## What does this PR do?
- Refactor segment_manager.search_logs to be a bit easier to read. This is preparation work to support boolean queries.

## How does this PR work? (optional)
- Factors out the search for posting lists and the search for matching document IDs into helper methods. We will eventually call these helper functions from an AST traversal.

## Refer to a related PR or issue link
- None

## Checklist

- [X]  I have written the necessary rustdoc comments - N/A for this change
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
