### PR TITLE
Fix references in segment.search_logs

### DIFF
--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -388,7 +388,7 @@ impl Segment {
         Some(result) => *result,
         None => {
           // Term not found.
-          return; // is this right?
+          return;
         }
       };
       let postings_list = match self.inverted_map.get(&term_id) {
@@ -613,7 +613,6 @@ impl Segment {
     range_start_time: u64,
     range_end_time: u64,
   ) -> Vec<LogMessage> {
-    // TODO: make the implementation below more performant by not decompressing every block in every postings list.
     let query_lowercase = query.to_lowercase();
     let terms = tokenize(&query_lowercase);
 

--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -633,15 +633,16 @@ impl Segment {
     let terms = tokenize(&query_lowercase);
     let mut results_accumulator = Vec::new();
 
-    // Call get_postings_lists and destructure its return value
+    // Get postings lists for the query terms
     let (postings_lists, last_block_list, initial_values_list, shortest_list_index) =
       self.get_postings_lists(&terms);
 
-    // No postings list was found so let's return empty handed.
+    // No postings lists were found so let's return empty handed
     if postings_lists.is_empty() {
       return vec![];
     }
 
+    // Now get the matching document IDs from the postings lists
     self.get_matching_doc_ids(
       &postings_lists,
       &last_block_list,


### PR DESCRIPTION
Fix broken unit tests caused by this:
https://github.com/infinohq/infino/commit/914b9b4d80db350bf77aa5e037a4784bfe67376b

## What does this PR do?
Fixes a unit test that was failing: index_manager::index::test_multiple_segments_logs

## How does this PR work? (optional)
Create the postings lists structures in get_postings_list and return them, rather than creating them a priori and passing in references.

## Checklist

- [X ]  I have written the necessary rustdoc comments.
-  X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
