### PR TITLE
Initial framework for Query DSL support

### DIFF
--- a/benches/src/logs/infino.rs
+++ b/benches/src/logs/infino.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 use chrono::Utc;
 use coredb::utils::config::Settings;
 use coredb::CoreDB;
+use serde_json::Value;
 
 use crate::utils::io;
 
@@ -63,9 +64,14 @@ impl InfinoEngine {
   /// Searches the given term and returns the time required in microseconds
   pub fn search_logs(&self, query: &str, range_start_time: u64, range_end_time: u64) -> u128 {
     let now = Instant::now();
+
+    // Passing an empty JSON object
+    let json_query = Value::Null;
+
     let result = self
       .coredb
-      .search_logs(query, range_start_time, range_end_time);
+      .search_logs(query, json_query, range_start_time, range_end_time);
+
     let elapsed = now.elapsed().as_micros();
     println!(
       "Infino time required for searching logs {} is : {} microseconds. Num of results {}",

--- a/coredb/src/lib.rs
+++ b/coredb/src/lib.rs
@@ -138,6 +138,7 @@ impl CoreDB {
   pub fn search_logs(
     &self,
     query: &str,
+    json_body: serde_json::Value,
     range_start_time: u64,
     range_end_time: u64,
   ) -> Vec<LogMessage> {
@@ -146,7 +147,7 @@ impl CoreDB {
       .get(self.get_default_index_name())
       .unwrap()
       .value()
-      .search_logs(query, range_start_time, range_end_time)
+      .search_logs(query, json_body, range_start_time, range_end_time)
   }
 
   /// Get the metric points for given label and range.
@@ -332,8 +333,11 @@ mod tests {
 
     let end = Utc::now().timestamp_millis() as u64;
 
+    // Prepare an empty JSON body for the query
+    let json_body = serde_json::Value::Null;
+
     // Search for log messages. The order of results should be reverse chronological order.
-    let results = coredb.search_logs("message", start, end);
+    let results = coredb.search_logs("message", json_body.clone(), start, end);
     assert_eq!(results.get(0).unwrap().get_text(), "log message 2");
     assert_eq!(results.get(1).unwrap().get_text(), "log message 1");
 


### PR DESCRIPTION
This is the initial framework to support Query DSL. It is backwards-compatible so current URL query parameters are still supported but the query terms can be overridden with an optional query via a JSON body attached to the REST request.

-->

## What does this PR do?
Creates an AST for all queries then traverses the AST to execute the query. A query formulated as a JSON body attached to GET request will override any URL query parameters. Basic boolean queries are now supported via the [Query DSL format](https://opensearch.org/docs/latest/query-dsl/compound/bool/).

## How does this PR work? (optional)
Modified segment query logic to always create an AST for queries, traverse that AST correctly, then execute the query. Note that this is a work in progress and only basic unit tests have been added as we are biasing for speed and this is an active area of the code base. The main concern was to ensure backwards compatibility so the code ensures all existing unit tests pass as currently constructed. 

By supporting Query DSL we will be able to better support all the languages supported by Elastic/OpenSearch (e.g. SQL, PPL, etc.).

## Refer to a related PR or issue link
[- (Related PR or issue)](https://github.com/infinohq/infino/issues/115)
[- (Related PR or issue)]https://github.com/infinohq/infino/issues/112

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X ]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
