### PR TITLE
Add unit tests to segment_manager/search.rs

### DIFF
--- a/coredb/src/log/postings_list.rs
+++ b/coredb/src/log/postings_list.rs
@@ -40,6 +40,20 @@ impl PostingsList {
     }
   }
 
+  // This constructor is only used in tests.
+  #[cfg(test)]
+  pub fn new_with_params(
+    compressed_blocks: Vec<PostingsBlockCompressed>,
+    last_block: PostingsBlock,
+    initial_values: Vec<u32>,
+  ) -> Self {
+    PostingsList {
+      postings_list_compressed: RwLock::new(compressed_blocks),
+      last_block: RwLock::new(last_block),
+      initial_values: RwLock::new(initial_values),
+    }
+  }
+
   /// Append a log message id to the postings list.
   pub fn append(&self, log_message_id: u32) {
     trace!("Appending log message id {}", log_message_id);

--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -80,6 +80,21 @@ impl Segment {
     }
   }
 
+  #[allow(dead_code)]
+  pub fn get_terms(&self) -> &DashMap<String, u32> {
+    &self.terms
+  }
+
+  #[allow(dead_code)]
+  pub fn get_inverted_map(&self) -> &DashMap<u32, PostingsList> {
+    &self.inverted_map
+  }
+
+  #[allow(dead_code)]
+  pub fn get_forward_map(&self) -> &DashMap<u32, LogMessage> {
+    &self.forward_map
+  }
+
   /// Get id of this segment.
   pub fn get_id(&self) -> &str {
     self.metadata.get_id()
@@ -486,14 +501,10 @@ mod tests {
   use crate::utils::sync::{is_sync, thread};
 
   fn create_term_test_node(term: &str) -> Result<Pairs<Rule>, pest::error::Error<Rule>> {
-    // Create a test string that should parse as a single term according to your grammar
     let test_string = term;
-
-    // Parse the test string and return the pairs
     QueryDslParser::parse(Rule::start, &test_string)
   }
 
-  // Populate segment with log messages for testing
   fn populate_segment(segment: &mut Segment) {
     let log_messages = vec![
       ("log 1", "this is a test log message"),
@@ -515,7 +526,6 @@ mod tests {
     let mut segment = Segment::new();
     populate_segment(&mut segment);
 
-    // Construct the query DSL as a JSON string for a Must query
     let query_dsl = r#"{
       "query": {
         "bool": {
@@ -527,7 +537,6 @@ mod tests {
     }
     "#;
 
-    // Parse the query DSL
     match QueryDslParser::parse(Rule::start, &query_dsl) {
       Ok(query_tree) => match segment.search_logs(&query_tree, 0, u64::MAX) {
         Ok(results) => {
@@ -585,7 +594,6 @@ mod tests {
     let mut segment = Segment::new();
     populate_segment(&mut segment);
 
-    // Construct the Query DSL query as a JSON string for a MustNot query
     let query_dsl_query = r#"{
       "query": {
         "bool": {
@@ -625,7 +633,6 @@ mod tests {
     let query_node_result = create_term_test_node("doesnotexist");
 
     if let Ok(query_node) = query_node_result {
-      // Assuming query_node is of the correct type expected by search_logs (e.g., Pair<Rule> or Pairs<Rule>)
       if let Err(err) = segment.search_logs(&query_node, 0, u64::MAX) {
         eprintln!("Error in search_logs: {:?}", err);
       } else {
@@ -645,7 +652,6 @@ mod tests {
     let query_node_result = create_term_test_node("doesnotexist");
 
     if let Ok(query_node) = query_node_result {
-      // Assuming query_node is of the correct type expected by search_logs (e.g., Pair<Rule> or Pairs<Rule>)
       if let Err(err) = segment.search_logs(&query_node, 0, u64::MAX) {
         eprintln!("Error in search_logs: {:?}", err);
       } else {
@@ -746,7 +752,6 @@ mod tests {
       100.0
     );
 
-    // Test search for "this".
     let query_node_result_for_this = create_term_test_node("this");
 
     if let Ok(query_node_for_this) = query_node_result_for_this {
@@ -761,12 +766,10 @@ mod tests {
         }
         Err(err) => {
           eprintln!("Error in search_logs for 'this': {:?}", err);
-          // Handle the error as needed, e.g., assert an expected error code
         }
       }
     } else {
       eprintln!("Error parsing the query for 'this'.");
-      // Handle the parsing error as needed, e.g., assert an expected error code
     }
 
     // Test search for "blah".


### PR DESCRIPTION
Adding unit tests to search.rs

## What does this PR do?
- Add basic unit tests. Segment.rs, at least for now, also runs its unit tests against this code (without mocking it).

## How does this PR work? (optional)
- Unit tests for search operations

## Refer to a related PR or issue link
- https://github.com/infinohq/infino/issues/112

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
