### PR TITLE
Make clippy run for tests and fail rust-check if there are warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "server", "coredb", "benches"
 ]
+resolver = "2"
 
 [profile.release]
 opt-level = 3

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ run-debug:
 rust-check:
 	cargo fmt --all -- --check
 	cargo check
-	cargo clippy
+	cargo clippy --all-targets --all-features -- -D warnings
 
 docker-check:
 	@docker ps > /dev/null 2>&1 || (echo "Docker is not running. Please start Docker to run all tests." && exit 1)

--- a/benches/src/logs/infino_rest.rs
+++ b/benches/src/logs/infino_rest.rs
@@ -31,7 +31,7 @@ impl InfinoApiClient {
 
     if let Ok(lines) = io::read_lines(input_data_path) {
       let client = reqwest::Client::new();
-      for (_index, line) in lines.enumerate() {
+      for line in lines {
         num_docs += 1;
         num_docs_in_this_batch += 1;
 

--- a/coredb/src/index_manager/index.rs
+++ b/coredb/src/index_manager/index.rs
@@ -964,7 +964,7 @@ mod tests {
         .expect("Could not refresh index");
       let (original_segment, original_segment_size) = Segment::refresh(
         &Storage::new(),
-        &original_segment_path
+        original_segment_path
           .to_str()
           .expect("Could not convert path to str"),
       )
@@ -1017,7 +1017,7 @@ mod tests {
       index.commit(true).await.expect("Could not commit index");
       let index = Index::refresh(&index_dir_path, 1024 * 1024).await.unwrap();
       let (mut original_segment, original_segment_size) =
-        Segment::refresh(&Storage::new(), &original_segment_path.to_str().unwrap())
+        Segment::refresh(&Storage::new(), original_segment_path.to_str().unwrap())
           .await
           .expect("Could not refresh segment");
       assert_eq!(index.memory_segments_map.len(), 2);
@@ -1075,7 +1075,7 @@ mod tests {
         .expect("Could not refresh index");
       (original_segment, _) = Segment::refresh(
         &Storage::new(),
-        &original_segment_path
+        original_segment_path
           .to_str()
           .expect("Could not refresh segment"),
       )
@@ -1273,7 +1273,7 @@ mod tests {
         index.append_log_message(
           Utc::now().timestamp_millis() as u64,
           &HashMap::new(),
-          &message,
+          message,
         );
       }
       index.commit(false).await.expect("Could not commit index");
@@ -1376,7 +1376,7 @@ mod tests {
 
     // Create a path within index_dir that does not exist.
     let temp_path_buf = index_dir.path().join("-doesnotexist");
-    let index = Index::new(&temp_path_buf.to_str().unwrap()).await.unwrap();
+    let index = Index::new(temp_path_buf.to_str().unwrap()).await.unwrap();
 
     // If we don't get any panic/error during commit, that means the commit is successful.
     index.commit(false).await.expect("Could not commit index");
@@ -1620,7 +1620,7 @@ mod tests {
     // Create a new index in an empty directory - this should work.
     let index_dir = TempDir::new("index_test").unwrap();
     let index_dir_path = index_dir.path().to_str().unwrap();
-    let index = Index::new_with_threshold_params(&index_dir_path, 1024, 1024 * 1024).await;
+    let index = Index::new_with_threshold_params(index_dir_path, 1024, 1024 * 1024).await;
     assert!(index.is_ok());
 
     // Create a new index in an non-empty directory that does not have metadata - this should give an error.
@@ -1628,7 +1628,7 @@ mod tests {
     let index_dir_path = index_dir.path().to_str().unwrap();
     let file_path = index_dir.path().join("my_file.txt");
     let _ = File::create(&file_path).unwrap();
-    let index = Index::new_with_threshold_params(&index_dir_path, 1024, 1024 * 1024).await;
+    let index = Index::new_with_threshold_params(index_dir_path, 1024, 1024 * 1024).await;
     assert!(index.is_err());
   }
 
@@ -1691,7 +1691,7 @@ mod tests {
       // Check that the queries for unique messages across the entire time range returns exactly one result.
       assert_eq!(
         index
-          .search_logs(&message_start, "", 0, u64::MAX)
+          .search_logs(message_start, "", 0, u64::MAX)
           .await
           .unwrap()
           .len(),
@@ -1699,7 +1699,7 @@ mod tests {
       );
       assert_eq!(
         index
-          .search_logs(&message_end, "", 0, u64::MAX)
+          .search_logs(message_end, "", 0, u64::MAX)
           .await
           .unwrap()
           .len(),
@@ -1709,7 +1709,7 @@ mod tests {
       // Check that the queries for unique messages across the specific time range returns exactly one result.
       assert_eq!(
         index
-          .search_logs(&message_start, "", start, end)
+          .search_logs(message_start, "", start, end)
           .await
           .unwrap()
           .len(),
@@ -1717,7 +1717,7 @@ mod tests {
       );
       assert_eq!(
         index
-          .search_logs(&message_end, "", start, end)
+          .search_logs(message_end, "", start, end)
           .await
           .unwrap()
           .len(),

--- a/coredb/src/index_manager/index.rs
+++ b/coredb/src/index_manager/index.rs
@@ -877,7 +877,7 @@ mod tests {
       Vec::new()
     };
     assert_eq!(results.len(), 1);
-    assert_eq!(results.get(0).unwrap().get_text(), "thisisunique");
+    assert_eq!(results.first().unwrap().get_text(), "thisisunique");
   }
 
   #[tokio::test]

--- a/coredb/src/index_manager/segment_summary.rs
+++ b/coredb/src/index_manager/segment_summary.rs
@@ -79,6 +79,10 @@ impl PartialEq for SegmentSummary {
 impl Eq for SegmentSummary {}
 
 impl PartialOrd for SegmentSummary {
+  // Suppress custom ordering warning - which happens in some Clippy versions.
+  // However, the specific warning can't be suppressed as older Clippy versions
+  // do not know about it.
+  #[allow(clippy::all)]
   fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
     other.end_time.partial_cmp(&self.end_time)
   }

--- a/coredb/src/lib.rs
+++ b/coredb/src/lib.rs
@@ -301,7 +301,7 @@ mod tests {
       let index_dir_path_line = format!("index_dir_path = \"{}\"\n", index_dir_path);
       let default_index_name_line = format!("default_index_name = \"{}\"\n", ".default");
 
-      let mut file = File::create(&config_file_path).unwrap();
+      let mut file = File::create(config_file_path).unwrap();
       file.write_all(b"[coredb]\n").unwrap();
       file.write_all(index_dir_path_line.as_bytes()).unwrap();
       file.write_all(default_index_name_line.as_bytes()).unwrap();
@@ -373,7 +373,7 @@ mod tests {
 
     // Search for metric points.
     let results = coredb
-      .get_metrics(&"__name__", &"some_metric", start, end)
+      .get_metrics("__name__", "some_metric", start, end)
       .await
       .expect("Error in get_metrics");
     assert_eq!(results.get(0).unwrap().get_value(), 1.0);

--- a/coredb/src/lib.rs
+++ b/coredb/src/lib.rs
@@ -367,7 +367,7 @@ mod tests {
         .search_logs("message", "", start, end)
         .await
         .expect("Error in search_logs");
-      assert_eq!(results.get(0).unwrap().get_text(), "log message 2");
+      assert_eq!(results.first().unwrap().get_text(), "log message 2");
       assert_eq!(results.get(1).unwrap().get_text(), "log message 1");
     }
 
@@ -376,7 +376,7 @@ mod tests {
       .get_metrics("__name__", "some_metric", start, end)
       .await
       .expect("Error in get_metrics");
-    assert_eq!(results.get(0).unwrap().get_value(), 1.0);
+    assert_eq!(results.first().unwrap().get_value(), 1.0);
     assert_eq!(results.get(1).unwrap().get_value(), 2.0);
   }
 }

--- a/coredb/src/log/postings_block.rs
+++ b/coredb/src/log/postings_block.rs
@@ -244,13 +244,12 @@ mod tests {
     pb.append(1000).unwrap();
     pb.append(2000).unwrap();
     pb.append(3000).unwrap();
-    let pb_clone = pb.clone();
-    assert_eq!(pb, pb_clone);
+    assert_eq!(pb, pb.clone());
 
     // Assert log message ids are same but not the same pointer
     assert_ne!(
       pb.get_log_message_ids().read().unwrap().as_ptr(),
-      pb_clone.get_log_message_ids().read().unwrap().as_ptr()
+      pb.clone().get_log_message_ids().read().unwrap().as_ptr()
     );
   }
 }

--- a/coredb/src/log/postings_block_compressed.rs
+++ b/coredb/src/log/postings_block_compressed.rs
@@ -270,9 +270,9 @@ mod tests {
     assert_eq!(pbc.log_message_ids_compressed.read().unwrap().len(), 16);
     assert_eq!(*pbc.log_message_ids_compressed.read().unwrap(), expected);
 
-    let mem_pb_log_message_ids = size_of_val(&*pb.get_log_message_ids().read().unwrap().as_slice());
+    let mem_pb_log_message_ids = size_of_val(pb.get_log_message_ids().read().unwrap().as_slice());
     let mem_pbc_log_message_ids_compressed =
-      size_of_val(&*pbc.log_message_ids_compressed.read().unwrap().as_slice());
+      size_of_val(pbc.log_message_ids_compressed.read().unwrap().as_slice());
 
     // The memory consumed by log_message_ids for uncompressed block should be equal to sizeof(u32)*128,
     // as there are 128 integers, each occupying 4 bytes.
@@ -280,7 +280,7 @@ mod tests {
 
     // The memory consumed by log_message_ids for compressed block should be equal to sizeof(u8)*16,
     // as there are 16 integers, each occupying 1 byte.
-    assert_eq!(mem_pbc_log_message_ids_compressed, 1 * 16);
+    assert_eq!(mem_pbc_log_message_ids_compressed, 16);
   }
 
   #[test]
@@ -292,12 +292,11 @@ mod tests {
     let pb = PostingsBlock::new_with_log_message_ids(increasing_by_one);
     let pbc = PostingsBlockCompressed::try_from(&pb).unwrap();
 
-    let pbc_clone = pbc.clone();
-    assert_eq!(pbc, pbc_clone);
+    assert_eq!(pbc, pbc.clone());
 
     assert_eq!(
       *pbc.log_message_ids_compressed.read().unwrap(),
-      *pbc_clone.log_message_ids_compressed.read().unwrap()
+      *pbc.clone().log_message_ids_compressed.read().unwrap()
     );
   }
 }

--- a/coredb/src/log/postings_list.rs
+++ b/coredb/src/log/postings_list.rs
@@ -187,15 +187,15 @@ mod tests {
         .get_log_message_ids()
         .read()
         .unwrap()
-        .get(0)
+        .first()
         .unwrap(),
-      &(100 as u32)
+      &(100_u32)
     );
 
     // Check that the first entry in the initial values is the same as what we appended.
     assert_eq!(
-      pl.get_initial_values().read().unwrap().get(0).unwrap(),
-      &(100 as u32)
+      pl.get_initial_values().read().unwrap().first().unwrap(),
+      &(100_u32)
     );
   }
 
@@ -220,8 +220,8 @@ mod tests {
     // The initial value length should be 1, with the only initial value being the very first value that was inserted.
     assert_eq!(pl.get_initial_values().read().unwrap().len(), 1);
     assert_eq!(
-      pl.get_initial_values().read().unwrap().get(0).unwrap(),
-      &(0 as u32)
+      pl.get_initial_values().read().unwrap().first().unwrap(),
+      &(0_u32)
     );
   }
 
@@ -236,14 +236,14 @@ mod tests {
 
     // Add an additional entry so that one more block is created.
     let second_block_initial_value = 10_001;
-    pl.append(second_block_initial_value as u32);
+    pl.append(second_block_initial_value);
 
     // There should be two blocks. The initial value of the first block should be the very first value appended,
     // while the initial value of the second block should be second_block_initial_value
     assert_eq!(pl.get_initial_values().read().unwrap().len(), 2);
     assert_eq!(
-      pl.get_initial_values().read().unwrap().get(0).unwrap(),
-      &(0 as u32)
+      pl.get_initial_values().read().unwrap().first().unwrap(),
+      &(0_u32)
     );
     assert_eq!(
       pl.get_initial_values().read().unwrap().get(1).unwrap(),
@@ -266,7 +266,7 @@ mod tests {
         .get_log_message_ids()
         .read()
         .unwrap()
-        .get(0)
+        .first()
         .unwrap(),
       &second_block_initial_value
     );

--- a/coredb/src/log/postings_list.rs
+++ b/coredb/src/log/postings_list.rs
@@ -253,7 +253,7 @@ mod tests {
     // The first block is compressed, and should have BLOCK_SIZE_FOR_LOG_MESSAGES entries.
     assert_eq!(pl.get_postings_list_compressed().read().unwrap().len(), 1);
     let first_compressed_postings_block_lock = pl.get_postings_list_compressed().read().unwrap();
-    let first_compressed_postings_block = first_compressed_postings_block_lock.get(0).unwrap();
+    let first_compressed_postings_block = first_compressed_postings_block_lock.first().unwrap();
     let first_postings_block = PostingsBlock::try_from(first_compressed_postings_block).unwrap();
     assert_eq!(first_postings_block.len(), BLOCK_SIZE_FOR_LOG_MESSAGES);
 

--- a/coredb/src/metric/metricutils.rs
+++ b/coredb/src/metric/metricutils.rs
@@ -51,7 +51,7 @@ pub fn decompress_numeric_vector(compressed: &[u8]) -> Result<Vec<MetricPoint>, 
 
 /// Compress a given MetricPoint vector to a vector of u8 integers, using delta-of-delta compression.
 pub fn compress_metric_point_vector(metric_points: &[MetricPoint]) -> Vec<u8> {
-  let start_metric_point = metric_points.get(0).unwrap();
+  let start_metric_point = metric_points.first().unwrap();
   let start_time = start_metric_point.get_time();
 
   // We need to convert to/from metric_point::MetricPoint/tsz::DataPoint to avoid tsz::DataPoint in

--- a/coredb/src/metric/time_series.rs
+++ b/coredb/src/metric/time_series.rs
@@ -234,7 +234,7 @@ mod tests {
     assert_eq!(ts.last_block.read().unwrap().len(), 1);
     let last_block_lock = ts.last_block.read().unwrap();
     let time_series_metric_points = &*last_block_lock.get_metrics_metric_points().read().unwrap();
-    let metric_point = time_series_metric_points.get(0).unwrap();
+    let metric_point = time_series_metric_points.first().unwrap();
     assert_eq!(metric_point.get_time(), 100);
     assert_eq!(metric_point.get_value(), 200.0);
 
@@ -290,7 +290,7 @@ mod tests {
     );
 
     let uncompressed =
-      TimeSeriesBlock::try_from(ts.compressed_blocks.read().unwrap().get(0).unwrap()).unwrap();
+      TimeSeriesBlock::try_from(ts.compressed_blocks.read().unwrap().first().unwrap()).unwrap();
     assert_eq!(uncompressed.len(), BLOCK_SIZE_FOR_TIME_SERIES);
     let metric_points_lock = uncompressed.get_metrics_metric_points().read().unwrap();
     for i in 0..BLOCK_SIZE_FOR_TIME_SERIES {

--- a/coredb/src/metric/time_series.rs
+++ b/coredb/src/metric/time_series.rs
@@ -239,7 +239,7 @@ mod tests {
     assert_eq!(metric_point.get_value(), 200.0);
 
     assert_eq!(ts.initial_times.read().unwrap().len(), 1);
-    assert_eq!(ts.initial_times.read().unwrap().get(0).unwrap(), &100);
+    assert_eq!(ts.initial_times.read().unwrap().first().unwrap(), &100);
   }
 
   #[test]
@@ -256,7 +256,7 @@ mod tests {
       BLOCK_SIZE_FOR_TIME_SERIES
     );
     assert_eq!(ts.initial_times.read().unwrap().len(), 1);
-    assert_eq!(ts.initial_times.read().unwrap().get(0).unwrap(), &0);
+    assert_eq!(ts.initial_times.read().unwrap().first().unwrap(), &0);
 
     for i in 0..BLOCK_SIZE_FOR_TIME_SERIES {
       let last_block_lock = ts.last_block.read().unwrap();
@@ -283,7 +283,7 @@ mod tests {
     // There should be 2 initial_times per the two blocks, with start times 0 and
     // BLOCK_SIZE_FOR_TIME_SERIES
     assert_eq!(ts.initial_times.read().unwrap().len(), 2);
-    assert_eq!(ts.initial_times.read().unwrap().get(0).unwrap(), &0);
+    assert_eq!(ts.initial_times.read().unwrap().first().unwrap(), &0);
     assert_eq!(
       ts.initial_times.read().unwrap().get(1).unwrap(),
       &(BLOCK_SIZE_FOR_TIME_SERIES as u64)
@@ -306,7 +306,7 @@ mod tests {
     let ts = TimeSeries::new();
     let num_metric_points = num_blocks * BLOCK_SIZE_FOR_TIME_SERIES as u64;
     for i in 0..num_metric_points {
-      ts.append(i as u64, i as f64);
+      ts.append(i, i as f64);
     }
 
     assert_eq!(

--- a/coredb/src/metric/time_series_block.rs
+++ b/coredb/src/metric/time_series_block.rs
@@ -172,7 +172,13 @@ mod tests {
     tsb.append(1000, 1.0).unwrap();
     assert_eq!(tsb.metric_points.read().unwrap().len(), 1);
     assert_eq!(
-      tsb.metric_points.read().unwrap().get(0).unwrap().get_time(),
+      tsb
+        .metric_points
+        .read()
+        .unwrap()
+        .first()
+        .unwrap()
+        .get_time(),
       1000
     );
     assert_eq!(
@@ -180,7 +186,7 @@ mod tests {
         .metric_points
         .read()
         .unwrap()
-        .get(0)
+        .first()
         .unwrap()
         .get_value(),
       1.0

--- a/coredb/src/metric/time_series_block_compressed.rs
+++ b/coredb/src/metric/time_series_block_compressed.rs
@@ -165,7 +165,7 @@ mod tests {
 
     // Each metric points takes 16 bytes, so the memory requirement would be BLOCK_SIZE_FOR_TIME_SERIES*16.
     let received_metric_points = received.get_metrics_metric_points().read().unwrap();
-    let mem_decompressed = size_of_val(&*received_metric_points.as_slice());
+    let mem_decompressed = size_of_val(received_metric_points.as_slice());
     assert_eq!(mem_decompressed, BLOCK_SIZE_FOR_TIME_SERIES * 16);
 
     // Make sure that the compressed data is at least 1/10th of the original data size.

--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -518,9 +518,16 @@ mod tests {
 
   use crate::utils::sync::{is_sync_send, thread};
 
-  fn create_term_test_node(term: &str) -> Result<Pairs<Rule>, pest::error::Error<Rule>> {
+  fn create_term_test_node(term: &str) -> Result<Pairs<Rule>, Box<pest::error::Error<Rule>>> {
     let test_string = term;
-    QueryDslParser::parse(Rule::start, &test_string)
+    let result = QueryDslParser::parse(Rule::start, test_string);
+
+    match result {
+      Ok(pairs) => Ok(pairs),
+
+      // The error can be arbitrarily large. To utilize the stack effectively, Box the error and return.
+      Err(e) => Err(Box::new(e)),
+    }
   }
 
   fn populate_segment(segment: &mut Segment) {
@@ -555,7 +562,7 @@ mod tests {
     }
     "#;
 
-    match QueryDslParser::parse(Rule::start, &query_dsl) {
+    match QueryDslParser::parse(Rule::start, query_dsl) {
       Ok(query_tree) => match segment.search_logs(&query_tree, 0, u64::MAX) {
         Ok(results) => {
           assert!(results
@@ -563,11 +570,11 @@ mod tests {
             .all(|log| log.get_text().contains("test") && log.get_text().contains("log")));
         }
         Err(err) => {
-          assert!(false, "Error in search_logs: {:?}", err);
+          panic!("Error in search_logs: {:?}", err);
         }
       },
       Err(err) => {
-        assert!(false, "Error parsing query DSL: {:?}", err);
+        panic!("Error parsing query DSL: {:?}", err);
       }
     }
   }
@@ -590,7 +597,7 @@ mod tests {
     "#;
 
     // Parse the query DSL
-    match QueryDslParser::parse(Rule::start, &query_dsl) {
+    match QueryDslParser::parse(Rule::start, query_dsl) {
       Ok(query_tree) => match segment.search_logs(&query_tree, 0, u64::MAX) {
         Ok(results) => {
           assert!(results
@@ -598,11 +605,11 @@ mod tests {
             .any(|log| log.get_text().contains("another") || log.get_text().contains("different")));
         }
         Err(err) => {
-          assert!(false, "Error in search_logs: {:?}", err);
+          panic!("Error in search_logs: {:?}", err);
         }
       },
       Err(err) => {
-        assert!(false, "Error parsing query DSL: {:?}", err);
+        panic!("Error parsing query DSL: {:?}", err);
       }
     }
   }
@@ -624,7 +631,7 @@ mod tests {
     "#;
 
     // Parse the query DSL
-    match QueryDslParser::parse(Rule::start, &query_dsl_query) {
+    match QueryDslParser::parse(Rule::start, query_dsl_query) {
       Ok(query_tree) => match segment.search_logs(&query_tree, 0, u64::MAX) {
         Ok(results) => {
           assert!(!results
@@ -632,11 +639,11 @@ mod tests {
             .any(|log| log.get_text().contains("excluded")));
         }
         Err(err) => {
-          assert!(false, "Error in search_logs: {:?}", err);
+          panic!("Error in search_logs: {:?}", err);
         }
       },
       Err(err) => {
-        assert!(false, "Error parsing query DSL: {:?}", err);
+        panic!("Error parsing query DSL: {:?}", err);
       }
     }
   }

--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -531,7 +531,7 @@ mod tests {
   }
 
   fn populate_segment(segment: &mut Segment) {
-    let log_messages = vec![
+    let log_messages = [
       ("log 1", "this is a test log message"),
       ("log 2", "this is another log message"),
       ("log 3", "test log for different term"),
@@ -776,7 +776,7 @@ mod tests {
         .get_metrics_metric_points()
         .read()
         .unwrap()
-        .get(0)
+        .first()
         .unwrap()
         .get_value(),
       100.0
@@ -790,7 +790,7 @@ mod tests {
         Ok(logs) => {
           assert_eq!(logs.len(), 1);
           assert_eq!(
-            logs.get(0).unwrap().get_text(),
+            logs.first().unwrap().get_text(),
             "this is my 1st log message"
           );
         }

--- a/coredb/src/storage_manager/storage.rs
+++ b/coredb/src/storage_manager/storage.rs
@@ -86,7 +86,7 @@ mod tests {
       .await
       .expect("Could not read from storage");
     for i in 1..=num_keys {
-      assert!(received.get(&String::from(format!("{prefix}{i}"))).unwrap() == &i);
+      assert!(received.get(&format!("{prefix}{i}")).unwrap() == &i);
     }
     // The number of bytes read is uncompressed - so it should be equal to the uncompressed number of bytes written.
     assert!(num_bytes_read == uncompressed);
@@ -146,7 +146,7 @@ mod tests {
       .read(file_path)
       .await
       .expect("Could not read from storage");
-    assert!(received.len() == 0);
+    assert!(received.is_empty());
 
     // The number of bytes read is uncompressed - so it should be greater than or equal to the number of bytes written uncompressed.
     assert!(num_bytes_read == uncompressed);

--- a/coredb/src/utils/config.rs
+++ b/coredb/src/utils/config.rs
@@ -117,7 +117,7 @@ mod tests {
     // Check default settings.
     let config_file_path = get_joined_path(config_dir_path, DEFAULT_CONFIG_FILE_NAME);
     {
-      let mut file = File::create(&config_file_path).unwrap();
+      let mut file = File::create(config_file_path).unwrap();
       file.write_all(b"[coredb]\n").unwrap();
       file
         .write_all(b"index_dir_path = \"/var/index\"\n")
@@ -131,7 +131,7 @@ mod tests {
       file.write_all(b"memory_budget_megabytes = 4096\n").unwrap();
     }
 
-    let settings = Settings::new(&config_dir_path).unwrap();
+    let settings = Settings::new(config_dir_path).unwrap();
     let coredb_settings = settings.get_coredb_settings();
     assert_eq!(coredb_settings.get_index_dir_path(), "/var/index");
     assert_eq!(coredb_settings.get_default_index_name(), ".default");
@@ -156,19 +156,19 @@ mod tests {
       env::set_var("RUN_MODE", "SETTINGSTEST");
       let config_file_path = get_joined_path(config_dir_path, "settingstest.toml");
       {
-        let mut file = File::create(&config_file_path).unwrap();
+        let mut file = File::create(config_file_path).unwrap();
         file.write_all(b"[coredb]\n").unwrap();
         file
           .write_all(b"segment_size_threshold_megabytes=1\n")
           .unwrap();
         file.write_all(b"memory_budget_megabytes=4\n").unwrap();
       }
-      let settings = Settings::new(&config_dir_path).unwrap();
+      let settings = Settings::new(config_dir_path).unwrap();
       let coredb_settings = settings.get_coredb_settings();
       assert_eq!(coredb_settings.get_index_dir_path(), "/var/index");
       assert_eq!(
         coredb_settings.get_segment_size_threshold_bytes(),
-        1 * 1024 * 1024
+        1024 * 1024
       );
       assert_eq!(coredb_settings.get_memory_budget_bytes(), 4 * 1024 * 1024);
       assert_eq!(
@@ -187,7 +187,7 @@ mod tests {
     // Create a config where the memory budget is too low.
     let config_file_path = get_joined_path(config_dir_path, DEFAULT_CONFIG_FILE_NAME);
     {
-      let mut file = File::create(&config_file_path).unwrap();
+      let mut file = File::create(config_file_path).unwrap();
       file.write_all(b"[coredb]\n").unwrap();
       file
         .write_all(b"index_dir_path = \"/var/index\"\n")
@@ -202,7 +202,7 @@ mod tests {
     }
 
     // Make sure this config returns an error.
-    let result = Settings::new(&config_dir_path);
+    let result = Settings::new(config_dir_path);
     assert!(result.is_err());
   }
 }


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
We had missed running clippy for tests. This change runs it for all targets (including test), and fails the `make test` in case clippy generates warnings.

## Checklist

- [NA]  I have written the necessary rustdoc comments.
- [NA]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
