### PR TITLE
Fix HTTP lib incompatibility so OpenSearch Plugin builds for OpenSearch 2.x

### DIFF
--- a/plugins/infino-opensearch-plugin/build.gradle
+++ b/plugins/infino-opensearch-plugin/build.gradle
@@ -97,7 +97,7 @@ validateNebulaPom.enabled = false
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.11.1")
     }
 
     repositories {

--- a/plugins/infino-opensearch-plugin/src/test/java/org/opensearch/infino/InfinoPluginIT.java
+++ b/plugins/infino-opensearch-plugin/src/test/java/org/opensearch/infino/InfinoPluginIT.java
@@ -9,8 +9,8 @@
 package org.opensearch.infino;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
-import org.apache.hc.core5.http.ParseException;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.http.util.EntityUtils;
+import org.apache.http.ParseException;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.plugins.Plugin;
@@ -23,7 +23,6 @@ import java.util.Collections;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-
 
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)

--- a/plugins/infino-opensearch-plugin/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/plugins/infino-opensearch-plugin/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -5,4 +5,4 @@
         h: component
 
   - match:
-      $body: /^infino-opensearch-plugin-3.0.0-SNAPSHOT\n$/
+      $body: /^infino-opensearch-plugin-2.11.1\n$/


### PR DESCRIPTION
Update imported methods to use standard http lib 

## What does this PR do?
- Fixes a broken import for use with OpenSearch 2.x

## How does this PR work? (optional)
- Changed the import 

## Refer to a related PR or issue link
- [(Related PR or issue)](https://github.com/infinohq/infino/issues/185)

## Checklist

- [X ]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
