### PR TITLE
Update infino Dockerfile to use a base image with rust 1.75.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Image to build infino release binary.
-FROM rust:1.67 as builder
+FROM rust:1.75 as builder
 
 WORKDIR /usr/src/infino
 COPY . .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,18 @@
 # Image to build infino release binary.
-FROM rust:1.75 as builder
+FROM rust:1.75.0-bookworm as builder
 
 WORKDIR /usr/src/infino
 COPY . .
 RUN cargo build --release
 
 # Smaller image for running infino.
-FROM debian:bullseye
+FROM debian:bookworm-slim
 WORKDIR /opt/infino
-RUN apt-get update & apt-get install -y extra-runtime-dependencies & rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y extra-runtime-dependencies && \
+    apt-get autoremove -y && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/src/infino/target/release/infino /opt/infino/infino
 COPY --from=builder /usr/src/infino/config /opt/infino/config
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,12 +7,9 @@ RUN cargo build --release
 
 # Smaller image for running infino.
 FROM debian:bookworm-slim
+
 WORKDIR /opt/infino
-RUN apt-get update && \
-    apt-get install -y extra-runtime-dependencies && \
-    apt-get autoremove -y && \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /usr/src/infino/target/release/infino /opt/infino/infino
 COPY --from=builder /usr/src/infino/config /opt/infino/config
 


### PR DESCRIPTION
# What does the PR do?
- It updates the base image used to `rust-1.75.0-bookworm` and
- updates final image to use `debian:bookworm-slim` to be consistent with builder image distro.

# Why is this PR needed?
The docker build uses `rust-1.67` as the base image and latest version of infino does not build in rust 1.67. Updating the base image used to `rust-1.75.0-bookworm` (latest stable at the moment). Not using `rust:latest` to avoid builds automatically moving to newer versions that we haven't tested.

## Infino build in rust 1.67 fails for below reasons
- `predicates v3.0.4` cannot be built because it requires rustc 1.69.0
- package `anstyle v1.0.4` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.69.

# Testing
- [x] Tested by building and running infino docker image with the change.
