### PR TITLE
Update plugin build.gradle to publish version to plugin-descriptor.properties

### DIFF
--- a/plugins/infino-opensearch-plugin/build.gradle
+++ b/plugins/infino-opensearch-plugin/build.gradle
@@ -52,6 +52,7 @@ publishing {
             pom {
               name = pluginName
               description = pluginDescription
+              groupId = "org.opensearch.plugin"
               licenses {
                 license {
                   name = "The Apache License, Version 2.0"
@@ -80,14 +81,6 @@ sourceSets {
     }
 }
 
-opensearchplugin {
-    name "${pluginName}-${opensearch_version}"
-    description pluginDescription
-    classname "${projectPath}.${pathToPlugin}.${pluginClassName}"
-    licenseFile rootProject.file('LICENSE.txt')
-    noticeFile rootProject.file('NOTICE.txt')
-}
-
 // This requires an additional Jar not published as part of build-tools
 loggerUsageCheck.enabled = false
 
@@ -98,6 +91,12 @@ validateNebulaPom.enabled = false
 buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "2.11.1")
+        opensearch_group = "org.opensearch"
+
+        // breakdown something like "3.0.0-rc1-snapshot" to the aray
+        // ["3.0.0", "rc1", "SNAPSHOT"]. We'll need this to craft
+        // the plugin version in the allprojects block
+        opensearch_version_tokens = opensearch_version.tokenize('-')
     }
 
     repositories {
@@ -116,14 +115,37 @@ ext {
     // Function to pad version numbers for comparison
     def padVersion = { v -> v.tokenize('.').collect { String.format('%04d', it.toInteger()) }.join('.') }
 
-    // Getting and padding the OpenSearch version
-    opensearch_version = System.getProperty("opensearch.version", "2.11.1")
-    currentVersionPadded = padVersion(opensearch_version)
+    // padding the OpenSearch version
+    // grab just the version number (opensearch_version_tokens[0]) and ignore the
+    // the qualifiers like SNAPSHOT or beta etc.
+    currentVersionPadded = padVersion(opensearch_version_tokens[0])
     version210Padded = padVersion('2.10.0')
     version211Padded = padVersion('2.11.0')
     version29Padded = padVersion('2.9.0')
     version27Padded = padVersion('2.7.0')
     version26Padded = padVersion('2.6.0')
+}
+
+allprojects {
+    group = "org.opensearch"
+    // from the version tokens generated earlier craft the plugin version.
+    // OpenSearch convention recommends that if the OpenSearch version to
+    // plugin version mapping is as follows
+    //  3.0.0 -> 3.0.0.0
+    //  3.0.0-SNAPSHOT -> 3.0.0.0-SNAPSHOT
+    // Use the opensearch_version_tokens to craft the appropriate plugin versions
+    version = opensearch_version_tokens[0] + '.0'
+    if (opensearch_version_tokens.size > 1) {
+        version += '-' + opensearch_version_tokens.drop(1).join('-')
+    }
+}
+
+opensearchplugin {
+    name pluginName
+    description pluginDescription
+    classname "${projectPath}.${pathToPlugin}.${pluginClassName}"
+    licenseFile rootProject.file('LICENSE.txt')
+    noticeFile rootProject.file('NOTICE.txt')
 }
 
 dependencies {


### PR DESCRIPTION
## What does this PR do?
1. The patch updates build.gradle so that the plugin version is pushed to plugin-descriptor.properties and OpenSearch picks up the plugin version when the plugin is loaded. Please see the _Before_ and _After_ below.
2. It also fixes a minor issue that caused `padVersion` function to fail parsing the opensearch version when it is something like `3.0.0-SNAPSHOT`.

### Before fix
```
> curl -XGET "https://localhost:9200/_cat/plugins" -ku 'admin:admin'
25a4875cab2b infino-opensearch-plugin-2.11.1      unspecified
25a4875cab2b opensearch-alerting                  2.11.1.0
25a4875cab2b opensearch-anomaly-detection         2.11.1.0
25a4875cab2b opensearch-asynchronous-search       2.11.1.0
25a4875cab2b opensearch-cross-cluster-replication 2.11.1.0
25a4875cab2b opensearch-custom-codecs             2.11.1.0
25a4875cab2b opensearch-geospatial                2.11.1.0
25a4875cab2b opensearch-index-management          2.11.1.0
25a4875cab2b opensearch-job-scheduler             2.11.1.0
25a4875cab2b opensearch-knn                       2.11.1.0
25a4875cab2b opensearch-ml                        2.11.1.0
25a4875cab2b opensearch-neural-search             2.11.1.0
25a4875cab2b opensearch-notifications             2.11.1.0
25a4875cab2b opensearch-notifications-core        2.11.1.0
25a4875cab2b opensearch-observability             2.11.1.0
25a4875cab2b opensearch-performance-analyzer      2.11.1.0
25a4875cab2b opensearch-reports-scheduler         2.11.1.0
25a4875cab2b opensearch-security                  2.11.1.0
25a4875cab2b opensearch-security-analytics        2.11.1.0
25a4875cab2b opensearch-sql                       2.11.1.0
```

### After fix
```
> curl -XGET "https://localhost:9200/_cat/plugins" -ku 'admin:admin'
4bd582aa5dbd infino-opensearch-plugin             2.11.1.0
4bd582aa5dbd opensearch-alerting                  2.11.1.0
4bd582aa5dbd opensearch-anomaly-detection         2.11.1.0
4bd582aa5dbd opensearch-asynchronous-search       2.11.1.0
4bd582aa5dbd opensearch-cross-cluster-replication 2.11.1.0
4bd582aa5dbd opensearch-custom-codecs             2.11.1.0
4bd582aa5dbd opensearch-geospatial                2.11.1.0
4bd582aa5dbd opensearch-index-management          2.11.1.0
4bd582aa5dbd opensearch-job-scheduler             2.11.1.0
4bd582aa5dbd opensearch-knn                       2.11.1.0
4bd582aa5dbd opensearch-ml                        2.11.1.0
4bd582aa5dbd opensearch-neural-search             2.11.1.0
4bd582aa5dbd opensearch-notifications             2.11.1.0
4bd582aa5dbd opensearch-notifications-core        2.11.1.0
4bd582aa5dbd opensearch-observability             2.11.1.0
4bd582aa5dbd opensearch-performance-analyzer      2.11.1.0
4bd582aa5dbd opensearch-reports-scheduler         2.11.1.0
4bd582aa5dbd opensearch-security                  2.11.1.0
4bd582aa5dbd opensearch-security-analytics        2.11.1.0
4bd582aa5dbd opensearch-sql                       2.11.1.0
```

## Checklist
- [x] Successfully built and loaded the plugin in OpenSearch
