### PR TITLE
Adding debug_handler macro until we figure out the issue with AST not implementing Send trait

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -452,6 +452,8 @@ async fn append_metric(
 }
 
 /// Search logs in CoreDB.
+/// TODO: adding debug_handler macro until we figure out the issue with AST not implementing Send trait.
+#[debug_handler]
 async fn search_logs(
   State(state): State<Arc<AppState>>,
   Query(logs_query): Query<LogsQuery>,


### PR DESCRIPTION

<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Simple one-line to add debug_handler, which gives readable Axum errors. This is needed until we settle on the way to pass AST across threads.

