### PR TITLE
Add a config variable to control the interface on which infino listens

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -1,7 +1,7 @@
 [coredb]
 # Storage configuration.
-storage_type = "local"                # can be "local", "aws", "gcp" or "azure"
-aws_bucket_name = "dev-infino-data"   # only relevant for storage type "aws"
+storage_type = "local"              # can be "local", "aws", "gcp" or "azure"
+aws_bucket_name = "dev-infino-data" # only relevant for storage type "aws"
 index_dir_path = "data"
 
 # Index configuration.
@@ -12,6 +12,7 @@ memory_budget_megabytes = 1024
 
 [server]
 port = 3000
+host = "127.0.0.1"
 commit_interval_in_seconds = 30
 timestamp_key = "date"
 labels_key = "labels"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -228,19 +228,21 @@ async fn main() {
 
   // Start server.
   let port = shared_state.settings.get_server_settings().get_port();
-  let connection_string = &format!("127.0.0.1:{}", port);
+  let host: &str = shared_state.settings.get_server_settings().get_host();
+  let connection_string = &format!("{}:{}", host, port);
   let listener = TcpListener::bind(connection_string)
     .await
     .unwrap_or_else(|_| panic!("Could not listen using {}", connection_string));
+
+  info!(
+    "Starting Infino server on {}. Use Ctrl-C or SIGTERM to gracefully exit...",
+    connection_string
+  );
 
   axum::serve(listener, app)
     .with_graceful_shutdown(shutdown_signal())
     .await
     .unwrap();
-  info!(
-    "Infino server listening on {}. Use Ctrl-C or SIGTERM to gracefully exit...",
-    connection_string
-  );
 
   if shared_state.queue.is_some() {
     info!("Closing RabbitMQ connection...");
@@ -769,6 +771,7 @@ mod tests {
       // Write server section.
       file.write_all(b"[server]\n").unwrap();
       file.write_all(b"port = 3000\n").unwrap();
+      file.write_all(b"host = \"127.0.0.1\"\n").unwrap();
       file.write_all(b"commit_interval_in_seconds = 1\n").unwrap();
       file.write_all(b"timestamp_key = \"date\"\n").unwrap();
       file.write_all(b"labels_key = \"labels\"\n").unwrap();

--- a/server/src/utils/settings.rs
+++ b/server/src/utils/settings.rs
@@ -12,6 +12,7 @@ const DEFAULT_CONFIG_FILE_NAME: &str = "default.toml";
 pub struct ServerSettings {
   commit_interval_in_seconds: u32,
   port: u16,
+  host: String,
   timestamp_key: String,
   labels_key: String,
   use_rabbitmq: bool,
@@ -26,6 +27,11 @@ impl ServerSettings {
   /// Get the port.
   pub fn get_port(&self) -> u16 {
     self.port
+  }
+
+  /// Get the host.
+  pub fn get_host(&self) -> &str {
+    &self.host
   }
 
   /// Get the key for timestamp in json.
@@ -133,6 +139,7 @@ mod tests {
     let server_settings = settings.get_server_settings();
     assert_eq!(server_settings.get_commit_interval_in_seconds(), 30);
     assert_eq!(server_settings.get_port(), 3000);
+    assert_eq!(server_settings.get_host(), "127.0.0.1");
     assert_eq!(server_settings.get_timestamp_key(), "date");
     assert_eq!(server_settings.get_labels_key(), "labels");
 


### PR DESCRIPTION

## What does this PR do?
- Adds support for specifying `host` config variable in config/default.toml to control the interface on which infino listens. Earlier infino was always listening on 127.0.0.1 and it was not possible to easily connect to it from outside the vm or host or container on which infino was running.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
