### PR TITLE
Print stacktrace by default when a test fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ docker-check:
 
 test: rust-check docker-check
 	echo "Running tests for all the packages"
-	cargo test --all
+	RUST_BACKTRACE=1 cargo test --all
 
 build:
 	cargo build $(release)


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
- Summarize your change (**mandatory**)

## How does this PR work? (optional)
Print stacktrace by default when a test fails
