### PR TITLE
feat: gcp support for storage

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -1,7 +1,7 @@
 [coredb]
 # Storage configuration.
 storage_type = "local"                # can be "local", "aws", "gcp" or "azure"
-aws_bucket_name = "dev-infino-data"   # only relevant for storage type "aws"
+cloud_storage_bucket_name = "dev-infino-data"   # only relevant if storage type is "aws", "gcp", or "azure"
 index_dir_path = "data"
 
 # Index configuration.

--- a/config/default.toml
+++ b/config/default.toml
@@ -3,6 +3,7 @@
 storage_type = "local"                # can be "local", "aws", "gcp" or "azure"
 cloud_storage_bucket_name = "dev-infino-data"   # only relevant if storage type is "aws", "gcp", or "azure"
 index_dir_path = "data"
+# "cloud_storage_region" can be used to set a region for the cloud provider
 
 # Index configuration.
 default_index_name = ".default"

--- a/coredb/Cargo.toml
+++ b/coredb/Cargo.toml
@@ -14,7 +14,6 @@ crossbeam = "0.8.2"
 futures = "0.3.30"
 dashmap = { version = "5.4.0", features = ["serde"] }
 dotenv = "0.15.0"
-futures = "0.3"
 google-cloud-storage = "0.15.0"
 lazy_static = "1.4.0"
 log = "0.4"

--- a/coredb/Cargo.toml
+++ b/coredb/Cargo.toml
@@ -14,9 +14,10 @@ crossbeam = "0.8.2"
 dashmap = { version = "5.4.0", features = ["serde"] }
 dotenv = "0.15.0"
 futures = "0.3"
+google-cloud-storage = "0.15.0"
 lazy_static = "1.4.0"
 log = "0.4"
-object_store = { version = "0.9.0", features = ["aws"] }
+object_store = { version = "0.9.0", features = ["aws", "gcp"] }
 pest = "2.7.6"
 pest_derive = "2.7.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/coredb/src/segment_manager/metadata.rs
+++ b/coredb/src/segment_manager/metadata.rs
@@ -5,7 +5,7 @@ use crossbeam::atomic::AtomicCell;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::storage_manager::storage::COMPRESSION_LEVEL;
+use crate::storage_manager::constants::COMPRESSION_LEVEL;
 use crate::utils::custom_serde::atomic_cell_serde;
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/coredb/src/storage_manager/aws_s3_utils.rs
+++ b/coredb/src/storage_manager/aws_s3_utils.rs
@@ -1,3 +1,7 @@
+// This code is licensed under Elastic License 2.0
+// https://www.elastic.co/licensing/elastic-license
+
+use aws_config::BehaviorVersion;
 use aws_config::Region;
 use aws_sdk_s3::Client;
 
@@ -12,9 +16,14 @@ pub struct AWSS3Utils {
 }
 
 impl AWSS3Utils {
-  pub async fn new() -> Result<Self, CoreDBError> {
-    // Load configuration from the environment and create the S3 client.
-    let config = aws_config::load_defaults(aws_config::BehaviorVersion::v2023_11_09()).await;
+  pub async fn new(region: &str) -> Result<Self, CoreDBError> {
+    // Load configuration from the environment, use the region set by user and create the S3 client.
+
+    let config = aws_config::defaults(BehaviorVersion::v2023_11_09())
+      .region(Region::new(region.to_owned()))
+      .load()
+      .await;
+
     let client = Client::new(&config);
 
     // Determine the region to use for the bucket location constraint.
@@ -81,7 +90,7 @@ mod tests {
     }
 
     // Check a bucket that should exist.
-    let utils = AWSS3Utils::new().await.unwrap();
+    let utils = AWSS3Utils::new("us-east-1").await.unwrap();
     assert!(utils.check_bucket_exists("dev-infino-unit-test").await);
 
     // Check a bucket that does not exist.

--- a/coredb/src/storage_manager/constants.rs
+++ b/coredb/src/storage_manager/constants.rs
@@ -1,0 +1,10 @@
+// This code is licensed under Elastic License 2.0
+// https://www.elastic.co/licensing/elastic-license
+
+/// Default cloud region for AWS S3.
+pub const DEFAULT_CLOUD_REGION_FOR_AWS_S3: &str = "us-east-1";
+
+/// Default cloud region for GCP.
+pub const DEFAULT_CLOUD_REGION_FOR_GCP: &str = "US-EAST1";
+
+pub const COMPRESSION_LEVEL: i32 = 15;

--- a/coredb/src/storage_manager/gcp_storage_utils.rs
+++ b/coredb/src/storage_manager/gcp_storage_utils.rs
@@ -1,5 +1,7 @@
-use crate::utils::error::CoreDBError;
+// This code is licensed under Elastic License 2.0
+// https://www.elastic.co/licensing/elastic-license
 
+use crate::utils::error::CoreDBError;
 use google_cloud_storage::client::{Client, ClientConfig};
 use google_cloud_storage::http::buckets::get::GetBucketRequest;
 use google_cloud_storage::http::buckets::insert::{
@@ -15,7 +17,7 @@ pub struct GCPStorageUtils {
 }
 
 impl GCPStorageUtils {
-  pub async fn new() -> Result<Self, CoreDBError> {
+  pub async fn new(region: &str) -> Result<Self, CoreDBError> {
     // Load configuration from the environment and create the GCP client.
     let config = match ClientConfig::default().with_auth().await {
       Ok(cfg) => cfg,
@@ -38,7 +40,7 @@ impl GCPStorageUtils {
 
     Ok(Self {
       client,
-      region: "US-EAST1".to_owned(),
+      region: region.to_owned(),
       project_id,
     })
   }
@@ -120,7 +122,7 @@ mod tests {
     }
 
     // Check a bucket that should exist.
-    let utils = GCPStorageUtils::new().await.unwrap();
+    let utils = GCPStorageUtils::new("US-EAST5").await.unwrap();
     assert!(utils.check_bucket_exists("dev-infino-unit-test").await);
 
     // Check a bucket that does not exist.
@@ -131,7 +133,7 @@ mod tests {
     );
 
     // Create a bucket that exists - the operation should succeed.
-    let response = utils.create_bucket("dev-infino-unit-test").await;
+    let response = utils.create_bucket("dev-infino-unit-test-east5").await;
     assert!(response.is_ok());
   }
 }

--- a/coredb/src/storage_manager/gcp_storage_utils.rs
+++ b/coredb/src/storage_manager/gcp_storage_utils.rs
@@ -1,0 +1,137 @@
+use crate::utils::error::CoreDBError;
+
+use google_cloud_storage::client::{Client, ClientConfig};
+use google_cloud_storage::http::buckets::get::GetBucketRequest;
+use google_cloud_storage::http::buckets::insert::{
+  BucketCreationConfig, InsertBucketParam, InsertBucketRequest,
+};
+use google_cloud_storage::http::Error;
+
+// project_id, and region is necessary for bucket creation operation
+pub struct GCPStorageUtils {
+  client: Client,
+  region: String,
+  project_id: String,
+}
+
+impl GCPStorageUtils {
+  pub async fn new() -> Result<Self, CoreDBError> {
+    // Load configuration from the environment and create the GCP client.
+    let config = match ClientConfig::default().with_auth().await {
+      Ok(cfg) => cfg,
+      Err(err) => {
+        return Err(CoreDBError::IOError(err.to_string()));
+      }
+    };
+
+    let project_id = match config.project_id.clone() {
+      Some(id) => id,
+      None => {
+        // If project_id is not present, return an error
+        return Err(CoreDBError::GCPStorageUtilsError(String::from(
+          "Project ID is missing",
+        )));
+      }
+    };
+
+    let client = Client::new(config);
+
+    Ok(Self {
+      client: client,
+      region: "US-EAST1".to_owned(),
+      project_id: project_id,
+    })
+  }
+
+  pub async fn create_bucket(&self, bucket_name: &str) -> Result<String, CoreDBError> {
+    let bucket_creation_result = self
+      .client
+      .insert_bucket(&InsertBucketRequest {
+        name: bucket_name.to_owned(),
+        bucket: BucketCreationConfig {
+          location: self.region.clone(),
+          ..Default::default()
+        },
+        param: InsertBucketParam {
+          project: self.project_id.clone(),
+          ..Default::default()
+        },
+      })
+      .await;
+
+    if let Err(err) = bucket_creation_result {
+      match err {
+        Error::Response(response_err) => {
+          if response_err.code == 409 {
+            // Bucket with same name already exists
+            return Ok(bucket_name.to_owned());
+          } else {
+            return Err(CoreDBError::GCPStorageUtilsError(format!(
+              "Google Cloud Storage error: {}",
+              response_err.code
+            )));
+          }
+        }
+        _ => {
+          return Err(CoreDBError::GCPStorageUtilsError(err.to_string()));
+        }
+      }
+    }
+
+    return Ok(bucket_name.to_owned());
+  }
+
+  pub async fn check_bucket_exists(&self, bucket_name: &str) -> bool {
+    // fetch the bucket to check if it exists
+    let bucket_result = self
+      .client
+      .get_bucket(&GetBucketRequest {
+        bucket: bucket_name.to_owned(),
+        ..Default::default()
+      })
+      .await;
+
+    // Check if there's an error
+    if let Err(_) = bucket_result {
+      return false;
+    }
+
+    // If there's no error, bucket is present
+    return true;
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  use std::env;
+
+  use crate::utils::environment::load_env;
+
+  #[tokio::test]
+  async fn test_gcp_storage_utils() {
+    // Load environment variables - esp creds for accessing non-local storage.
+    load_env();
+
+    // Do not run this test in Github Actions, and do not run it if the GCP credentials are not set.
+    if env::var("GITHUB_ACTIONS").is_ok() || env::var("GOOGLE_APPLICATION_CREDENTIALS").is_err() {
+      return;
+    }
+
+    // Check a bucket that should exist.
+    let utils = GCPStorageUtils::new().await.unwrap();
+    assert!(utils.check_bucket_exists("dev-infino-unit-test").await);
+
+    // Check a bucket that does not exist.
+    assert!(
+      !(utils
+        .check_bucket_exists("dev-infino-bucket-does-not-exist")
+        .await)
+    );
+
+    // Create a bucket that exists - the operation should succeed.
+    let response = utils.create_bucket("dev-infino-unit-test").await;
+    assert!(response.is_ok());
+  }
+}

--- a/coredb/src/storage_manager/gcp_storage_utils.rs
+++ b/coredb/src/storage_manager/gcp_storage_utils.rs
@@ -37,9 +37,9 @@ impl GCPStorageUtils {
     let client = Client::new(config);
 
     Ok(Self {
-      client: client,
+      client,
       region: "US-EAST1".to_owned(),
-      project_id: project_id,
+      project_id,
     })
   }
 
@@ -78,7 +78,7 @@ impl GCPStorageUtils {
       }
     }
 
-    return Ok(bucket_name.to_owned());
+    Ok(bucket_name.to_owned())
   }
 
   pub async fn check_bucket_exists(&self, bucket_name: &str) -> bool {
@@ -92,12 +92,12 @@ impl GCPStorageUtils {
       .await;
 
     // Check if there's an error
-    if let Err(_) = bucket_result {
+    if bucket_result.is_err() {
       return false;
     }
 
     // If there's no error, bucket is present
-    return true;
+    true
   }
 }
 

--- a/coredb/src/storage_manager/mod.rs
+++ b/coredb/src/storage_manager/mod.rs
@@ -1,3 +1,4 @@
 pub mod aws_s3_utils;
+pub mod constants;
 pub mod gcp_storage_utils;
 pub mod storage;

--- a/coredb/src/storage_manager/mod.rs
+++ b/coredb/src/storage_manager/mod.rs
@@ -1,2 +1,3 @@
 pub mod aws_s3_utils;
+pub mod gcp_storage_utils;
 pub mod storage;

--- a/coredb/src/storage_manager/storage.rs
+++ b/coredb/src/storage_manager/storage.rs
@@ -1,3 +1,6 @@
+// This code is licensed under Elastic License 2.0
+// https://www.elastic.co/licensing/elastic-license
+
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -10,17 +13,23 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::storage_manager::aws_s3_utils::AWSS3Utils;
+use crate::storage_manager::constants::COMPRESSION_LEVEL;
 use crate::storage_manager::gcp_storage_utils::GCPStorageUtils;
 use crate::utils::error::CoreDBError;
 
 // Level for zstd compression. Higher level means higher compression ratio, at the expense of speed of compression and decompression.
-pub const COMPRESSION_LEVEL: i32 = 15;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CloudStorageConfig {
+  pub bucket_name: String,
+  pub region: String,
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum StorageType {
   Local,
-  Aws(String), // AWS storage with bucket name.
-  Gcp(String), // GCP storage with bucket name.
+  Aws(CloudStorageConfig), // AWS storage with bucket name.
+  Gcp(CloudStorageConfig), // GCP storage with bucket name.
 }
 
 #[derive(Debug)]
@@ -34,9 +43,11 @@ impl Storage {
   pub async fn new(storage_type: &StorageType) -> Result<Self, CoreDBError> {
     let object_store: Arc<dyn ObjectStore> = match storage_type {
       // AWS storage. Create the bucket if it doesn't exist.
-      StorageType::Aws(bucket_name) => {
+      StorageType::Aws(cloud_storage_config) => {
         // Check if the bucket exists.
-        let aws_s3_utils = AWSS3Utils::new().await?;
+        let aws_s3_utils = AWSS3Utils::new(&cloud_storage_config.region).await?;
+        let bucket_name = &cloud_storage_config.bucket_name;
+
         let exists = aws_s3_utils.check_bucket_exists(bucket_name).await;
         if !exists {
           log::info!("Bucket {} doesn't exist. Creating it.", bucket_name);
@@ -52,15 +63,18 @@ impl Storage {
       // Local storage.
       StorageType::Local => Arc::new(LocalFileSystem::new()),
 
-      // GCP Cloud Storage, creates a bucket if it does not exists
-      StorageType::Gcp(bucket_name) => {
-        let gcp_storage_utils = GCPStorageUtils::new().await?;
+      // GCP Cloud Storage, creates a bucket if it does not exist.
+      StorageType::Gcp(cloud_storage_config) => {
+        let gcp_storage_utils = GCPStorageUtils::new(&cloud_storage_config.region).await?;
+
+        let bucket_name = &cloud_storage_config.bucket_name;
         let exists = gcp_storage_utils.check_bucket_exists(bucket_name).await;
         if !exists {
           log::info!("Bucket {} doesn't exist. Creating it.", bucket_name);
           gcp_storage_utils.create_bucket(bucket_name).await?;
         }
 
+        // Make sure to have path to json file with gcp credentials in SERVICE_ACCOUNT env varq
         let gcs_store = GoogleCloudStorageBuilder::from_env()
           .with_bucket_name(bucket_name.to_owned())
           .build()?;
@@ -241,8 +255,14 @@ mod tests {
   }
 
   #[test_case(StorageType::Local; "with local storage")]
-  #[test_case(StorageType::Aws("dev-infino-unit-test".to_owned()); "with AWS storage")]
-  #[test_case(StorageType::Gcp("dev-infino-unit-test".to_owned()); "with GCP storage")]
+  #[test_case(StorageType::Aws(CloudStorageConfig {
+    bucket_name: "dev-infino-unit-test".to_owned(),
+    region: "us-east-1".to_owned(),
+  }))]
+  #[test_case(StorageType::Gcp(CloudStorageConfig {
+    bucket_name: "dev-infino-unit-test".to_owned(),
+    region: "US-EAST1".to_owned(),
+  }))]
   #[tokio::test]
   async fn test_serialize_btree_map(storage_type: StorageType) {
     // Load environment variables - esp creds for accessing non-local storage.
@@ -284,8 +304,14 @@ mod tests {
   }
 
   #[test_case(StorageType::Local; "with local storage")]
-  #[test_case(StorageType::Aws("dev-infino-unit-test".to_owned()); "with AWS storage")]
-  #[test_case(StorageType::Gcp("dev-infino-unit-test".to_owned()); "with GCP storage")]
+  #[test_case(StorageType::Aws(CloudStorageConfig {
+    bucket_name: "dev-infino-unit-test".to_owned(),
+    region: "us-east-1".to_owned(),
+  }))]
+  #[test_case(StorageType::Gcp(CloudStorageConfig {
+    bucket_name: "dev-infino-unit-test".to_owned(),
+    region: "US-EAST1".to_owned(),
+  }))]
   #[tokio::test]
   async fn test_serialize_vec(storage_type: StorageType) {
     // Load environment variables - esp creds for accessing non-local storage.
@@ -329,8 +355,14 @@ mod tests {
   }
 
   #[test_case(StorageType::Local; "with local storage")]
-  #[test_case(StorageType::Aws("dev-infino-unit-test".to_owned()); "with AWS storage")]
-  #[test_case(StorageType::Gcp("dev-infino-unit-test".to_owned()); "with GCP storage")]
+  #[test_case(StorageType::Aws(CloudStorageConfig {
+      bucket_name: "dev-infino-unit-test".to_owned(),
+      region: "us-east-1".to_owned(),
+    }))]
+  #[test_case(StorageType::Gcp(CloudStorageConfig {
+      bucket_name: "dev-infino-unit-test".to_owned(),
+      region: "US-EAST1".to_owned(),
+    }))]
   #[tokio::test]
   async fn test_empty(storage_type: StorageType) {
     // Load environment variables - esp creds for accessing non-local storage.
@@ -366,8 +398,14 @@ mod tests {
   }
 
   #[test_case(StorageType::Local; "with local storage")]
-  #[test_case(StorageType::Aws("dev-infino-unit-test".to_owned()); "with AWS storage")]
-  #[test_case(StorageType::Gcp("dev-infino-unit-test".to_owned()); "with GCP storage")]
+  #[test_case(StorageType::Aws(CloudStorageConfig {
+      bucket_name: "dev-infino-unit-test".to_owned(),
+      region: "us-east-1".to_owned(),
+    }))]
+  #[test_case(StorageType::Gcp(CloudStorageConfig {
+      bucket_name: "dev-infino-unit-test".to_owned(),
+      region: "US-EAST1".to_owned(),
+   }))]
   #[tokio::test]
   async fn test_create_dir(storage_type: StorageType) {
     // Load environment variables - esp creds for accessing non-local storage.
@@ -394,8 +432,14 @@ mod tests {
   }
 
   #[test_case(StorageType::Local; "with local storage")]
-  #[test_case(StorageType::Aws("dev-infino-unit-test".to_owned()); "with AWS storage")]
-  #[test_case(StorageType::Gcp("dev-infino-unit-test".to_owned()); "with GCP storage")]
+  #[test_case(StorageType::Aws(CloudStorageConfig {
+      bucket_name: "dev-infino-unit-test".to_owned(),
+      region: "us-east-1".to_owned(),
+    }))]
+  #[test_case(StorageType::Gcp(CloudStorageConfig {
+      bucket_name: "dev-infino-unit-test".to_owned(),
+      region: "US-EAST1".to_owned(),
+    }))]
   #[tokio::test]
   async fn test_prefix(storage_type: StorageType) {
     // Load environment variables - esp creds for accessing non-local storage.

--- a/coredb/src/utils/config.rs
+++ b/coredb/src/utils/config.rs
@@ -87,16 +87,16 @@ impl CoreDBSettings {
               "AWS bucket name (as cloud_storage_bucket_name) not provided".to_owned(),
             ))?;
         Ok(StorageType::Aws(aws_bucket_name))
-      },
+      }
       "gcp" => {
         let gcp_bucket_name =
-        self
-          .cloud_storage_bucket_name
-          .to_owned()
-          .ok_or(CoreDBError::InvalidConfiguration(
-            "GCP bucket name (as cloud_storage_bucket_name) not provided".to_owned(),
-          ))?;
-      Ok(StorageType::Gcp(gcp_bucket_name))
+          self
+            .cloud_storage_bucket_name
+            .to_owned()
+            .ok_or(CoreDBError::InvalidConfiguration(
+              "GCP bucket name (as cloud_storage_bucket_name) not provided".to_owned(),
+            ))?;
+        Ok(StorageType::Gcp(gcp_bucket_name))
       }
       _ => {
         let message = format!("Unknown storage type: {}", self.storage_type);
@@ -143,7 +143,9 @@ impl Settings {
       ));
     }
 
-    if settings.coredb.storage_type != "local" && settings.coredb.cloud_storage_bucket_name.is_none() {
+    if settings.coredb.storage_type != "local"
+      && settings.coredb.cloud_storage_bucket_name.is_none()
+    {
       return Err(ConfigError::Message(
         "Cloud Storage bucket name is not set".to_owned(),
       ));

--- a/coredb/src/utils/config.rs
+++ b/coredb/src/utils/config.rs
@@ -25,7 +25,7 @@ pub struct CoreDBSettings {
   memory_budget_megabytes: f32,
 
   storage_type: String,
-  aws_bucket_name: Option<String>,
+  cloud_storage_bucket_name: Option<String>,
 }
 
 impl CoreDBSettings {
@@ -77,12 +77,22 @@ impl CoreDBSettings {
       "aws" => {
         let aws_bucket_name =
           self
-            .aws_bucket_name
+            .cloud_storage_bucket_name
             .to_owned()
             .ok_or(CoreDBError::InvalidConfiguration(
-              "AWS bucket name not provided".to_owned(),
+              "AWS bucket name (as cloud_storage_bucket_name) not provided".to_owned(),
             ))?;
         Ok(StorageType::Aws(aws_bucket_name))
+      },
+      "gcp" => {
+        let gcp_bucket_name =
+        self
+          .cloud_storage_bucket_name
+          .to_owned()
+          .ok_or(CoreDBError::InvalidConfiguration(
+            "GCP bucket name (as cloud_storage_bucket_name) not provided".to_owned(),
+          ))?;
+      Ok(StorageType::Gcp(gcp_bucket_name))
       }
       _ => {
         let message = format!("Unknown storage type: {}", self.storage_type);
@@ -129,9 +139,9 @@ impl Settings {
       ));
     }
 
-    if settings.coredb.storage_type == "aws" && settings.coredb.aws_bucket_name.is_none() {
+    if settings.coredb.storage_type != "local" && settings.coredb.cloud_storage_bucket_name.is_none() {
       return Err(ConfigError::Message(
-        "AWS bucket name is not set".to_owned(),
+        "Cloud Storage bucket name is not set".to_owned(),
       ));
     }
 

--- a/coredb/src/utils/error.rs
+++ b/coredb/src/utils/error.rs
@@ -50,6 +50,9 @@ pub enum CoreDBError {
 
   #[error("AWS SDK Error: {0}")]
   AwsSdkError(String),
+
+  #[error("GCP Storage Utils Error: {0}")]
+  GCPStorageUtilsError(String),
 }
 
 #[derive(Debug, Error, Eq, PartialEq)]


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
- Added GCP support for storage.

## How does this PR work? (optional)
- Added an additional `StorageType` for gcp.
- Created a new module in storage manager, `GCPStorageUtils` to enable bucket creation, etc.
- Unified the bucket_name in config to a singular `cloud_storage_bucket_name`, rather than having separate for each cloud provider

## Refer to a related PR or issue link
- N.A.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
