### PR TITLE
Update infino Dockerfile to install libssl3 in base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,10 +3,26 @@ FROM rust:1.75.0-bookworm as builder
 
 WORKDIR /usr/src/infino
 COPY . .
-RUN cargo build --release
+
+# The built-in libgit in cargo can lead to ot of memory
+# errors on low memory machines. If git is installed then
+# use the system git by setting CARGO_NET_GIT_FETCH_WITH_CLI=true,
+# otherwis let cargo use its libgit.
+RUN command git -v > /dev/null 2>&1 && \
+    CARGO_NET_GIT_FETCH_WITH_CLI=true cargo build --release || \
+    cargo build --release
 
 # Smaller image for running infino.
 FROM debian:bookworm-slim
+
+# Install libssl shared library as infino depends on it and
+# libssl3 is not available in the debian:bookworm-slim image.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && \
+    apt-get install -y libssl3 && \
+    # Cleanup after the installs to remove the apt cache and any temporary files
+    apt-get autoremove -y && \
+    apt-get clean -y && \
+    rm -fr /var/lib/apt/lists/*
 
 WORKDIR /opt/infino
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM rust:1.75.0-bookworm as builder
 WORKDIR /usr/src/infino
 COPY . .
 
-# The built-in libgit in cargo can lead to ot of memory
+# The built-in libgit in cargo can lead to out of memory
 # errors on low memory machines. If git is installed then
 # use the system git by setting CARGO_NET_GIT_FETCH_WITH_CLI=true,
 # otherwis let cargo use its libgit.


### PR DESCRIPTION

## What does this PR do?
- Install libssl3 in the base image `debian:bookworm-slim`. Latest infino binary dynamically links to libssl3 and the base image does not have.
- Minor update to the `cargo build --release` command in the builder image to use system git if available. Reason: cargo's libgit causes OOM issues, especially when building multi-arch images.

## Checklist

- [x] Built docker image with latest infino code, ran the container and accessed infino at http://localhost:3000/ping