### PR TITLE
Fix overflow sustraction error when two empty segments get created with initial time of 0

### DIFF
--- a/coredb/src/metric/time_series.rs
+++ b/coredb/src/metric/time_series.rs
@@ -113,7 +113,12 @@ impl TimeSeries {
         let block_start = *initial_times.get(i).unwrap();
 
         // The maximum block end time would be one less than the start time of the next block.
-        let block_end = initial_times.get(i + 1).unwrap() - 1;
+        let next_block_start = initial_times.get(i + 1).unwrap();
+        let block_end = if next_block_start > &0 {
+          next_block_start - 1
+        } else {
+          0
+        };
 
         if is_overlap(block_start, block_end, range_start_time, range_end_time) {
           let compressed_block = compressed_blocks.get(i).unwrap();


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Sometimes, esp in memory constrained environment and in a scenario where the time starts from 0, we may run into `attempt to subtract with overflow` error. This PR fixes the same.
