### PR TITLE
Do not block commit thread, if a previous commit is already running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,5 +59,5 @@ docker-push: docker-check
 # Rust example for indexing Apache logs.
 # You can run this as below (Infino server must be running to run this example):
 # `make example-apache-logs file=examples/datasets/apache-tiny.log count=100000`
-example-apache-logs:
+example-apache-logs: build
 	cargo run $(release) --bin rust-apache-logs -- --file $(file) --count $(count)


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
If a previous commit is already running, a new commit can block while acquiring a lock. This causes an issue when the segment sizes are large, or disk is slow, etc. Instead, return immediately. (The next invocation of commit will be happening on a schedule anyway).

## How does this PR work? (optional)
- Need a brief introduction for the changed logic (optional)

## Refer to a related PR or issue link
- (Related PR or issue)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
