### PR TITLE
Change plugin license to Elastic

### DIFF
--- a/plugins/infino-opensearch-plugin/src/main/java/org/opensearch/infino/InfinoRestHandler.java
+++ b/plugins/infino-opensearch-plugin/src/main/java/org/opensearch/infino/InfinoRestHandler.java
@@ -1,10 +1,7 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
-*/
+/** 
+/* This code is licensed under Elastic License 2.0
+/* https://www.elastic.co/licensing/elastic-license
+/**
 
 package org.opensearch.infino;
 

--- a/plugins/infino-opensearch-plugin/src/main/java/org/opensearch/infino/InfinoSerializeRequestURI.java
+++ b/plugins/infino-opensearch-plugin/src/main/java/org/opensearch/infino/InfinoSerializeRequestURI.java
@@ -1,10 +1,7 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
+/**
+/* This code is licensed under Elastic License 2.0
+/* https://www.elastic.co/licensing/elastic-license
+/**
 
 package org.opensearch.infino;
 

--- a/plugins/infino-opensearch-plugin/src/test/java/org/opensearch/infino/InfinoRestHandlerTests.java
+++ b/plugins/infino-opensearch-plugin/src/test/java/org/opensearch/infino/InfinoRestHandlerTests.java
@@ -1,10 +1,7 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
+/**
+/* This code is licensed under Elastic License 2.0
+/* https://www.elastic.co/licensing/elastic-license
+/**
 
 package org.opensearch.infino;
 

--- a/plugins/infino-opensearch-plugin/src/test/java/org/opensearch/infino/InfinoSerializeRequestURITests.java
+++ b/plugins/infino-opensearch-plugin/src/test/java/org/opensearch/infino/InfinoSerializeRequestURITests.java
@@ -1,10 +1,7 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
+/**
+/* This code is licensed under Elastic License 2.0
+/* https://www.elastic.co/licensing/elastic-license
+/**
 
 package org.opensearch.infino;
 


### PR DESCRIPTION
Change the plugin license to Elastic.
-->

## What does this PR do?
- Changes the license of the plugin code that we wrote. For code that is substantially the same as open source we are keeping as Apache.

## How does this PR work? (optional)
- N/A

