### PR TITLE
Plugin: fix compile errors and disable opensearch's license header checks

### DIFF
--- a/plugins/infino-opensearch-plugin/build.gradle
+++ b/plugins/infino-opensearch-plugin/build.gradle
@@ -19,8 +19,8 @@ sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
 // We don't have to use OpenSearch license for this plugin
-tasks.named("dependencyLicenses").configure { it.enabled = false }
-dependenciesInfo.enabled = false
+licenseHeaders.enabled = false
+dependencyLicenses.enabled = false
 
 // jarhell 
 jarHell.enabled = false
@@ -227,4 +227,3 @@ task updateVersion {
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
     }
 }
-

--- a/plugins/infino-opensearch-plugin/src/main/java/org/opensearch/infino/InfinoRestHandler.java
+++ b/plugins/infino-opensearch-plugin/src/main/java/org/opensearch/infino/InfinoRestHandler.java
@@ -1,7 +1,7 @@
 /** 
 /* This code is licensed under Elastic License 2.0
 /* https://www.elastic.co/licensing/elastic-license
-/**
+**/
 
 package org.opensearch.infino;
 

--- a/plugins/infino-opensearch-plugin/src/main/java/org/opensearch/infino/InfinoSerializeRequestURI.java
+++ b/plugins/infino-opensearch-plugin/src/main/java/org/opensearch/infino/InfinoSerializeRequestURI.java
@@ -1,7 +1,7 @@
 /**
 /* This code is licensed under Elastic License 2.0
 /* https://www.elastic.co/licensing/elastic-license
-/**
+**/
 
 package org.opensearch.infino;
 

--- a/plugins/infino-opensearch-plugin/src/test/java/org/opensearch/infino/InfinoRestHandlerTests.java
+++ b/plugins/infino-opensearch-plugin/src/test/java/org/opensearch/infino/InfinoRestHandlerTests.java
@@ -1,7 +1,7 @@
 /**
 /* This code is licensed under Elastic License 2.0
 /* https://www.elastic.co/licensing/elastic-license
-/**
+**/
 
 package org.opensearch.infino;
 

--- a/plugins/infino-opensearch-plugin/src/test/java/org/opensearch/infino/InfinoSerializeRequestURITests.java
+++ b/plugins/infino-opensearch-plugin/src/test/java/org/opensearch/infino/InfinoSerializeRequestURITests.java
@@ -1,7 +1,7 @@
 /**
 /* This code is licensed under Elastic License 2.0
 /* https://www.elastic.co/licensing/elastic-license
-/**
+**/
 
 package org.opensearch.infino;
 


### PR DESCRIPTION
- A typo in previous checkin caused plugin builds to fail with a compile error. This PR fixes the typo.
- OpenSearch license header checks disallow the new elastic license. This PR disables license header checks in build.gradle.

## Checklist

- [x]  Built the plugin and ran unit tests.