### PR TITLE
Remove RwLock from PostingsBlockCompressed and TimeSeriesCompressed - as these are not mutated once created

### DIFF
--- a/coredb/src/log/postings_block.rs
+++ b/coredb/src/log/postings_block.rs
@@ -135,10 +135,7 @@ impl TryFrom<&PostingsBlockCompressed> for PostingsBlock {
 
     BITPACKER.decompress_sorted(
       initial,
-      &postings_block_compressed
-        .get_log_message_ids_compressed()
-        .read()
-        .unwrap(),
+      postings_block_compressed.get_log_message_ids_compressed(),
       &mut decompressed[..],
       num_bits,
     );

--- a/coredb/src/log/postings_block_compressed.rs
+++ b/coredb/src/log/postings_block_compressed.rs
@@ -124,7 +124,7 @@ impl Clone for PostingsBlockCompressed {
     PostingsBlockCompressed::new_with_params(
       self.get_initial(),
       self.get_num_bits(),
-      &self.get_log_message_ids_compressed(),
+      self.get_log_message_ids_compressed(),
     )
   }
 }

--- a/coredb/src/metric/time_series_block.rs
+++ b/coredb/src/metric/time_series_block.rs
@@ -120,11 +120,7 @@ impl TryFrom<&TimeSeriesBlockCompressed> for TimeSeriesBlock {
   fn try_from(
     time_series_block_compressed: &TimeSeriesBlockCompressed,
   ) -> Result<Self, Self::Error> {
-    let metric_points_compressed_lock = time_series_block_compressed
-      .get_metric_points_compressed()
-      .read()
-      .unwrap();
-    let metric_points_compressed = &*metric_points_compressed_lock;
+    let metric_points_compressed = time_series_block_compressed.get_metric_points_compressed();
     let metric_points_decompressed = decompress_numeric_vector(metric_points_compressed).unwrap();
     let time_series_block = TimeSeriesBlock::new_with_metric_points(metric_points_decompressed);
 


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Remove locking from PostingsBlockCompressed and TimeSeriesCompressed - as these are created once and not mutated afterwards.

## Checklist

- [X]  Ran existing concurrency tests to make sure the behavior of the program is correct under different circumstances