### PR TITLE
Partially optimize tokenize function to use Vec<&str>

### DIFF
--- a/coredb/src/log/log_message.rs
+++ b/coredb/src/log/log_message.rs
@@ -57,18 +57,24 @@ impl LogMessage {
   }
 
   /// Get the terms corresponding to this log message.
+  //
+  // TODO: This function could be optimized to reduce string operations. We process
+  // the strings dynamically (e.g., changing case, adding FIELD_DELIMITER, etc) so it
+  // it isn't as straightforward.
   pub fn get_terms(&self) -> Vec<String> {
-    let text_lower = self.text.to_lowercase();
+    let text = self.text.to_lowercase();
     let mut terms: Vec<String> = Vec::new();
 
     // Each word in text goes as it is in terms.
-    let tokens = tokenize(&text_lower);
-    terms.extend(tokens);
+    let mut tokens = Vec::new();
+    tokenize(&text, &mut tokens);
+    terms.extend(tokens.into_iter().map(|s| s.to_string()));
 
     // Each word in a field value goes with a perfix a of its field name, followed by ":".
     for field in &self.fields {
       let name = field.0;
-      let values = tokenize(field.1);
+      let mut values = Vec::new();
+      tokenize(field.1, &mut values);
       for value in values {
         let term = format!("{}{}{}", name, FIELD_DELIMITER, value);
         terms.push(term);

--- a/coredb/src/segment_manager/query_dsl.rs
+++ b/coredb/src/segment_manager/query_dsl.rs
@@ -275,7 +275,8 @@ impl Segment {
       query_text.to_owned()
     };
 
-    let terms = tokenize(&query);
+    let mut terms = Vec::new();
+    tokenize(&query, &mut terms);
 
     // If fieldname is provided, concatenate it with each term; otherwise, use the term as is
     let transformed_terms: Vec<String> = terms
@@ -284,7 +285,7 @@ impl Segment {
         if let Some(field) = fieldname {
           format!("{}~{}", field, term)
         } else {
-          term
+          term.to_owned()
         }
       })
       .collect();

--- a/coredb/src/segment_manager/search.rs
+++ b/coredb/src/segment_manager/search.rs
@@ -108,7 +108,7 @@ impl Segment {
     &self,
     postings_lists: &[Vec<PostingsBlockCompressed>],
     last_block_list: &[PostingsBlock<BLOCK_SIZE_FOR_LOG_MESSAGES>],
-    initial_values_list: &Vec<Vec<u32>>,
+    initial_values_list: &[Vec<u32>],
     shortest_list_index: usize,
     result_set: &mut HashSet<u32>,
   ) -> Result<(), AstError> {

--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -174,8 +174,6 @@ impl Segment {
     let terms = log_message.get_terms();
 
     let log_message_id = self.metadata.fetch_increment_log_message_count();
-    // Update the forward map.
-    self.forward_map.insert(log_message_id, log_message); // insert in forward map
 
     // Update the inverted map.
     for term in terms {
@@ -201,6 +199,9 @@ impl Segment {
         pl.append(log_message_id);
       }
     }
+
+    // Update the forward map.
+    self.forward_map.insert(log_message_id, log_message); // insert in forward map
 
     self.update_start_end_time(time);
     Ok(())

--- a/coredb/src/utils/tokenize.rs
+++ b/coredb/src/utils/tokenize.rs
@@ -5,21 +5,8 @@ use unicode_segmentation::UnicodeSegmentation;
 
 pub const FIELD_DELIMITER: char = '~';
 
-/// Tokenize input string, and add the tokens to the output vector.
-/// The input string is assumed to not contain FIELD_DELIMITER, or the tokenization
-/// is expected to not do any special processing on FIELD_DELIMITER.
-///
-/// This is an optimization typically useful during insertions (see LogMessage::get_terms),
-/// where we do not want to tokenize on FIELD_DELIMITER.
-pub fn tokenize_without_field_delimiter<'a>(input: &'a str, output: &mut Vec<&'a str>) {
-  let tokens = input.unicode_words();
-  output.extend(tokens);
-}
-
 /// Tokenize a given string. Note that FIELD_DELIMITER is a special character that we
 /// use a field separator in queries, and so we do not tokenize on "~".
-///
-/// Note that for input such as "a~b c"
 pub fn tokenize<'a>(input: &'a str, output: &mut Vec<&'a str>) {
   if !input.contains(FIELD_DELIMITER) {
     // Input does not have FIELD_DELIMITER, so just do unicode_words().

--- a/coredb/src/utils/tokenize.rs
+++ b/coredb/src/utils/tokenize.rs
@@ -5,42 +5,71 @@ use unicode_segmentation::UnicodeSegmentation;
 
 pub const FIELD_DELIMITER: char = '~';
 
-// Tokenize a given string. Note that FIELD_DELIMITER is a special character that we
-// use a field separator in queries, and so we do not tokenize on "~".
-pub fn tokenize(input: &str) -> Vec<String> {
+/// Tokenize input string, and add the tokens to the output vector.
+/// The input string is assumed to not contain FIELD_DELIMITER, or the tokenization
+/// is expected to not do any special processing on FIELD_DELIMITER.
+///
+/// This is an optimization typically useful during insertions (see LogMessage::get_terms),
+/// where we do not want to tokenize on FIELD_DELIMITER.
+pub fn tokenize_without_field_delimiter<'a>(input: &'a str, output: &mut Vec<&'a str>) {
+  let tokens = input.unicode_words();
+  output.extend(tokens);
+}
+
+/// Tokenize a given string. Note that FIELD_DELIMITER is a special character that we
+/// use a field separator in queries, and so we do not tokenize on "~".
+///
+/// Note that for input such as "a~b c"
+pub fn tokenize<'a>(input: &'a str, output: &mut Vec<&'a str>) {
   if !input.contains(FIELD_DELIMITER) {
     // Input does not have FIELD_DELIMITER, so just do unicode_words().
     // This improves performance in this hot method, as we do not need to split
     // the input on FIELD_DELIMITER.
     let tokens: Vec<&str> = input.unicode_words().collect();
-    return tokens.iter().map(|x| x.to_string()).collect();
+    output.extend(tokens);
+    return;
   }
 
-  // Input has FIELD_DELIMITER, so we need to do a bit more work.
-  // We need to split the input on FIELD_DELIMITER, and then tokenize each segment.
+  // Temporary storage for combining tokens with '~'
+  let mut current_token: Option<&'a str> = None;
 
-  // First, create different segments based on FIELD_DELIMITER separator.
-  let segments: Vec<&str> = input.split(FIELD_DELIMITER).collect();
+  // Iterate through the unicode words
+  for word in input.unicode_words() {
+    let start = word.as_ptr() as usize - input.as_ptr() as usize;
+    let end = start + word.len();
 
-  let mut tokens: Vec<String> = Vec::new();
-  for segment in segments {
-    // Unicode tokenize each segment.
-    let words: Vec<&str> = segment.unicode_words().collect();
-
-    // Merge each segment, making sure to add the special delimiter FIELD_DELIMITER back at the end of each segment.
-    // As an example, if the first segment is vec!["a", "b"], and the next segment is vec!["c", "d"], and the
-    // field delimiter is "~", the tokens will be vec!["a", "b~c", "d"]
-    for (pos, word) in words.iter().enumerate() {
-      if pos == 0 && !tokens.is_empty() {
-        let word_with_tilde = format!("{}{}", FIELD_DELIMITER, word);
-        tokens.last_mut().unwrap().push_str(&word_with_tilde);
+    // Check if current_token is Some and should be combined with the current word
+    if let Some(ct) = current_token {
+      // Check if there's a '~' between the current token and the word
+      if &input[start - 1..start] == "~" {
+        let combined_start = ct.as_ptr() as usize - input.as_ptr() as usize;
+        output.push(&input[combined_start..end]);
+        current_token = None; // Reset current_token
+        continue;
       } else {
-        tokens.push(word.to_string());
+        // Push the previous token if it's not followed by '~'
+        output.push(ct);
+        current_token = None;
       }
+    }
+
+    // If there's no '~' directly before this word, set current_token to Some
+    if current_token.is_none() {
+      current_token = Some(word);
     }
   }
 
-  tokens
+  // Handle the last token
+  if let Some(ct) = current_token {
+    output.push(ct);
+  }
+
+  // Special handling for when the input itself ends with '~'
+  if input.ends_with('~') && !output.is_empty() {
+    let last = output.pop().unwrap(); // Safe because output is not empty
+    let combined_end = last.as_ptr() as usize - input.as_ptr() as usize + last.len() + 1; // +1 for '~'
+    output.push(&input[last.as_ptr() as usize - input.as_ptr() as usize..combined_end]);
+  }
 }
 
 #[cfg(test)]
@@ -49,27 +78,32 @@ mod tests {
 
   #[test]
   fn test_tokenize() {
-    let words = tokenize("a quick brown fox jumped 5.2 feet");
+    let mut words = Vec::new();
+    tokenize("a quick brown fox jumped 5.2 feet", &mut words);
     assert_eq!(
       words,
       vec!["a", "quick", "brown", "fox", "jumped", "5.2", "feet"]
     );
 
-    let words = tokenize("[notice]: this is last boarding call.");
+    let mut words = Vec::new();
+    tokenize("[notice]: this is last boarding call.", &mut words);
     assert_eq!(
       words,
       vec!["notice", "this", "is", "last", "boarding", "call"]
     );
 
-    let words = tokenize("He said, \"Hi, there!\"");
+    let mut words = Vec::new();
+    tokenize("He said, \"Hi, there!\"", &mut words);
     assert_eq!(words, vec!["He", "said", "Hi", "there"]);
 
     // "~" appearing at the beginning of the text does get treated a seperator,
     // while the one appearing in between doesn't.
-    let words = tokenize(&format!(
+    let mut words = Vec::new();
+    let input = &format!(
       "~sky:1 test{}2 thisisaword test{}345",
       FIELD_DELIMITER, FIELD_DELIMITER
-    ));
+    );
+    tokenize(input, &mut words);
     assert_eq!(
       words,
       vec![
@@ -81,10 +115,9 @@ mod tests {
       ]
     );
 
-    let words = tokenize(&format!(
-      "sky:1 test{}2 test{}345",
-      FIELD_DELIMITER, FIELD_DELIMITER
-    ));
+    let mut words = Vec::new();
+    let input = &format!("sky:1 test{}2 test{}345", FIELD_DELIMITER, FIELD_DELIMITER);
+    tokenize(input, &mut words);
     assert_eq!(
       words,
       vec![

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -886,7 +886,7 @@ mod tests {
     Ok(())
   }
 
-  fn check_metric_point_vectors(expected: &Vec<MetricPoint>, received: &Vec<MetricPoint>) {
+  fn check_metric_point_vectors(expected: &[MetricPoint], received: &[MetricPoint]) {
     assert_eq!(expected.len(), received.len());
 
     // The time series is sorted by time - and in tests we may insert multiple values at the same time instant.

--- a/server/src/utils/test_with_env_vars.rs
+++ b/server/src/utils/test_with_env_vars.rs
@@ -36,6 +36,7 @@ where
     }
   }
 
+  #[allow(clippy::blocks_in_conditions)]
   match panic::catch_unwind(|| {
     closure();
   }) {


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Optimized the tokenize function to use Vec<&str>. However, this is only partial since in LogMessage::get_terms(), we need to use Vec<String> as the strings are dynamically constructed.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
