### PR TITLE
Add a profiling program and make target for coredb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace]
 members = [
-    "server", "coredb"
+    "server", "coredb", "examples/rust-apache-logs"
 ]
 exclude = [
-    "benches", "examples/rust-apache-logs"
+    "benches"
 ]
 resolver = "2"
 

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,6 @@ run-debug:
 	echo "Running $(prog) server in debug mode..."
 	RUST_LOG=debug cargo run $(release) --bin $(prog)
 
-run-profile:
-	echo "Building $(prog) server using profile dhat..."
-	cargo build --profile dhat
-	cargo run --features dhat-heap --bin $(prog)
-
 rust-check:
 	cargo fmt --all -- --check
 	cargo check
@@ -83,3 +78,18 @@ docker-push: docker-check
 example-apache-logs:
 	cd examples/rust-apache-logs && \
 	cargo run $(release) --bin rust-apache-logs -- --file $(file) --count $(count)
+
+# Start Infino server for memory profiling using dhat.
+run-profile-server:
+	echo "Building $(prog) server using profile dhat..."
+	cargo build --profile dhat
+	cargo run --features dhat-heap --bin $(prog)
+
+# Run memory profiling using dhat for CoreDB.
+# # You can run this as below:
+# `make run-profile-coredb-only file=../datasets/apache-tiny.log count=100000`
+run-profile-coredb-only:
+	echo "Building $(prog) server using profile dhat..."
+	cargo build --profile dhat
+	cd examples/rust-apache-logs && \
+        cargo run --features dhat-heap --bin rust-apache-logs -- --coredb_only --file $(file) --count $(count)

--- a/examples/rust-apache-logs/Cargo.toml
+++ b/examples/rust-apache-logs/Cargo.toml
@@ -1,5 +1,3 @@
-[workspace]
-
 [package]
 name = "rust-apache-logs"
 version = "0.1.0"
@@ -8,7 +6,15 @@ edition = "2021"
 [dependencies]
 clap = "4.4.18"
 chrono = "0.4"
+coredb = { path = "../../coredb" }
+dhat = "0.3.2"
 reqwest = "0.11.23"
 serde = { version = "~1", features = ["derive"]}
 serde_json = "~1"
 tokio = { version = "1", features = ["full"] }
+
+[profile.release]
+debug = 1
+
+[features]
+dhat-heap = []    # if you are doing heap profiling using --coredb_only option


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
We currently only have support for profiling the server, which has a complicated setup and hard to compare against runs. Add support to profile only coredb, which is more comparable across runs.

