### PR TITLE
disable gradle buildserver in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,8 @@
 				// Disable rust analyzer running on save, so that it doesn't
 				// start automatically and consume CPU + Memory.
 				"rust-analyzer.checkOnSave": false,
-				"gradle.autoDetect": "off"
+				"gradle.autoDetect": "off",
+				"java.gradle.buildServer.enabled": "off"
 			},
 			"extensions": [
 				// List of vscode extensions to be installed in the devcontainer


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

The gradle vscode plugin was added to the devcontainer in a previous change. By default, gradle plugin starts building the gradle project and seems to be doing a lot of work in the background. Changing default behavior to off so that we run the gradle job manually when necessary.