### PR TITLE
prune the vscode extensions installed in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,16 +38,19 @@
 				// start automatically and consume CPU + Memory.
 				"rust-analyzer.checkOnSave": false,
 				"gradle.autoDetect": "off",
-				"java.gradle.buildServer.enabled": "off"
+				"java.gradle.buildServer.enabled": "off",
+				"java.import.gradle.enabled": false,
+				"java.configuration.detectJdksAtStart": false
 			},
 			"extensions": [
 				// List of vscode extensions to be installed in the devcontainer
 				"rust-lang.rust-analyzer",
 				"tamasfe.even-better-toml",
 				"ms-vscode.makefile-tools",
-				"vscjava.vscode-java-pack",
+				"vadimcn.vscode-lldb",
+				"redhat.java",
 				"vscjava.vscode-gradle",
-				"vadimcn.vscode-lldb"
+				"vscjava.vscode-java-debug"
 			]
 		}
 	},


### PR DESCRIPTION
Removed some extensions that we do not use and added some settings to disable plugins from starting tasks on launch of devcontainer.