### PR TITLE
Simplify locking for metrics

### DIFF
--- a/coredb/src/metric/time_series_block.rs
+++ b/coredb/src/metric/time_series_block.rs
@@ -8,16 +8,13 @@ use crate::metric::constants::BLOCK_SIZE_FOR_TIME_SERIES;
 use crate::metric::metric_point::MetricPoint;
 use crate::metric::metricutils::decompress_numeric_vector;
 use crate::metric::time_series_block_compressed::TimeSeriesBlockCompressed;
-use crate::utils::custom_serde::rwlock_serde;
 use crate::utils::error::CoreDBError;
-use crate::utils::sync::RwLock;
 
 /// Represents a time series block.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct TimeSeriesBlock {
-  #[serde(with = "rwlock_serde")]
   /// Vector of metric points, wrapped in a RwLock.
-  metric_points: RwLock<Vec<MetricPoint>>,
+  metric_points: Vec<MetricPoint>,
 }
 
 impl TimeSeriesBlock {
@@ -25,7 +22,7 @@ impl TimeSeriesBlock {
   pub fn new() -> Self {
     // We allocate a fixed capacity at the beginning, so that the vector doesn't get dynamically reallocated during appends.
     let metric_points_vec: Vec<MetricPoint> = Vec::with_capacity(BLOCK_SIZE_FOR_TIME_SERIES);
-    let metric_points_lock = RwLock::new(metric_points_vec);
+    let metric_points_lock = metric_points_vec;
 
     Self {
       metric_points: metric_points_lock,
@@ -34,28 +31,24 @@ impl TimeSeriesBlock {
 
   /// Create a time series block from the given vector of metric points.
   pub fn new_with_metric_points(metric_points_vec: Vec<MetricPoint>) -> Self {
-    let metric_points_lock = RwLock::new(metric_points_vec);
-
     Self {
-      metric_points: metric_points_lock,
+      metric_points: metric_points_vec,
     }
   }
 
   /// Check whether this time series block is empty.
   pub fn is_empty(&self) -> bool {
-    self.metric_points.read().unwrap().is_empty()
+    self.metric_points.is_empty()
   }
 
   /// Get the vector of metric points, wrapped in RwLock.
-  pub fn get_metrics_metric_points(&self) -> &RwLock<Vec<MetricPoint>> {
+  pub fn get_metric_points(&self) -> &Vec<MetricPoint> {
     &self.metric_points
   }
 
   /// Append a new metric point with given time and value.
-  pub fn append(&self, time: u64, value: f64) -> Result<(), CoreDBError> {
-    let mut metric_points_lock = self.metric_points.write().unwrap();
-
-    if metric_points_lock.len() >= BLOCK_SIZE_FOR_TIME_SERIES {
+  pub fn append(&mut self, time: u64, value: f64) -> Result<(), CoreDBError> {
+    if self.metric_points.len() >= BLOCK_SIZE_FOR_TIME_SERIES {
       debug!("Capacity full error while inserting time/value {}/{}. Typically a new block will now be created.",
              time, value);
       return Err(CoreDBError::CapacityFull(BLOCK_SIZE_FOR_TIME_SERIES));
@@ -64,11 +57,11 @@ impl TimeSeriesBlock {
     let dp = MetricPoint::new(time, value);
 
     // Always keep metric_points vector sorted (by time), as the compression needs it to be sorted.
-    if metric_points_lock.is_empty() || metric_points_lock.last().unwrap() < &dp {
-      metric_points_lock.push(dp);
+    if self.metric_points.is_empty() || self.metric_points.last().unwrap() < &dp {
+      self.metric_points.push(dp);
     } else {
-      let pos = metric_points_lock.binary_search(&dp).unwrap_or_else(|e| e);
-      metric_points_lock.insert(pos, dp);
+      let pos = self.metric_points.binary_search(&dp).unwrap_or_else(|e| e);
+      self.metric_points.insert(pos, dp);
     }
 
     Ok(())
@@ -80,10 +73,9 @@ impl TimeSeriesBlock {
     range_start_time: u64,
     range_end_time: u64,
   ) -> Vec<MetricPoint> {
-    let metric_points_lock = self.metric_points.read().unwrap();
     let mut retval = Vec::new();
 
-    for dp in metric_points_lock.as_slice() {
+    for dp in self.metric_points.as_slice() {
       let time = dp.get_time();
 
       if time >= range_start_time && time <= range_end_time {
@@ -97,17 +89,13 @@ impl TimeSeriesBlock {
   /// Get the number of metric points in this time series block.
   #[cfg(test)]
   pub fn len(&self) -> usize {
-    let metric_points_lock = self.metric_points.read().unwrap();
-    metric_points_lock.len()
+    self.metric_points.len()
   }
 }
 
 impl PartialEq for TimeSeriesBlock {
   fn eq(&self, other: &Self) -> bool {
-    let metric_points_lock = self.metric_points.read().unwrap();
-    let other_metric_points_lock = other.metric_points.read().unwrap();
-
-    *metric_points_lock == *other_metric_points_lock
+    self.metric_points == other.metric_points
   }
 }
 
@@ -136,13 +124,10 @@ impl Default for TimeSeriesBlock {
 
 #[cfg(test)]
 mod tests {
-  use std::sync::Arc;
-  use std::thread;
-
   use rand::Rng;
 
   use super::*;
-  use crate::utils::sync::is_sync_send;
+  use crate::utils::sync::{is_sync_send, thread, Arc, RwLock};
 
   #[test]
   fn test_new_time_series_block() {
@@ -151,47 +136,29 @@ mod tests {
 
     // Check that a new time series block is empty.
     let tsb = TimeSeriesBlock::new();
-    assert_eq!(tsb.metric_points.read().unwrap().len(), 0);
+    assert_eq!(tsb.metric_points.len(), 0);
   }
 
   #[test]
   fn test_default_time_series_block() {
     // Check that a default time series block is empty.
     let tsb = TimeSeriesBlock::default();
-    assert_eq!(tsb.metric_points.read().unwrap().len(), 0);
+    assert_eq!(tsb.metric_points.len(), 0);
   }
 
   #[test]
   fn test_single_append() {
     // After appending a single value, check that the time series block has that value.
-    let tsb = TimeSeriesBlock::new();
+    let mut tsb = TimeSeriesBlock::new();
     tsb.append(1000, 1.0).unwrap();
-    assert_eq!(tsb.metric_points.read().unwrap().len(), 1);
-    assert_eq!(
-      tsb
-        .metric_points
-        .read()
-        .unwrap()
-        .first()
-        .unwrap()
-        .get_time(),
-      1000
-    );
-    assert_eq!(
-      tsb
-        .metric_points
-        .read()
-        .unwrap()
-        .first()
-        .unwrap()
-        .get_value(),
-      1.0
-    );
+    assert_eq!(tsb.len(), 1);
+    assert_eq!(tsb.get_metric_points().first().unwrap().get_time(), 1000);
+    assert_eq!(tsb.get_metric_points().first().unwrap().get_value(), 1.0);
   }
 
   #[test]
   fn test_block_size_appends() {
-    let tsb = TimeSeriesBlock::new();
+    let mut tsb = TimeSeriesBlock::new();
     let mut expected: Vec<MetricPoint> = Vec::new();
 
     // Append BLOCK_SIZE_FOR_TIME_SERIES values, and check that the time series block has those values.
@@ -199,12 +166,12 @@ mod tests {
       tsb.append(i as u64, i as f64).unwrap();
       expected.push(MetricPoint::new(i as u64, i as f64));
     }
-    assert_eq!(*tsb.metric_points.read().unwrap(), expected);
+    assert_eq!(*tsb.get_metric_points(), expected);
   }
 
   #[test]
   fn test_metric_points_in_range() {
-    let tsb = TimeSeriesBlock::new();
+    let mut tsb = TimeSeriesBlock::new();
     tsb.append(100, 1.0).unwrap();
     tsb.append(200, 1.0).unwrap();
     tsb.append(300, 1.0).unwrap();
@@ -222,7 +189,7 @@ mod tests {
 
     let num_threads = 16;
     let num_metric_points_per_thread = BLOCK_SIZE_FOR_TIME_SERIES / 16;
-    let tsb = Arc::new(TimeSeriesBlock::new());
+    let tsb = Arc::new(RwLock::new(TimeSeriesBlock::new()));
 
     let mut handles = Vec::new();
     let expected = Arc::new(RwLock::new(Vec::new()));
@@ -234,7 +201,7 @@ mod tests {
         for _ in 0..num_metric_points_per_thread {
           let time = rng.gen_range(0..10000);
           let dp = MetricPoint::new(time, 1.0);
-          tsb_arc.append(time, 1.0).unwrap();
+          tsb_arc.write().unwrap().append(time, 1.0).unwrap();
           (*(expected_arc.write().unwrap())).push(dp);
         }
       });
@@ -250,11 +217,11 @@ mod tests {
 
     assert_eq!(
       *expected.read().unwrap(),
-      *tsb.metric_points.read().unwrap()
+      *tsb.read().unwrap().metric_points
     );
 
     // If we append more than BLOCK_SIZE, it should result in an error.
-    let retval = tsb.append(1000, 1000.0);
+    let retval = tsb.write().unwrap().append(1000, 1000.0);
     assert!(retval.is_err());
   }
 }

--- a/coredb/src/segment_manager/mod.rs
+++ b/coredb/src/segment_manager/mod.rs
@@ -10,3 +10,4 @@ mod metadata;
 pub(crate) mod query_dsl;
 pub(crate) mod search;
 pub(super) mod segment;
+pub(super) mod time_series_map;

--- a/coredb/src/segment_manager/time_series_map.rs
+++ b/coredb/src/segment_manager/time_series_map.rs
@@ -1,0 +1,194 @@
+use std::fmt;
+use std::sync::{Arc, RwLock};
+
+use dashmap::DashMap;
+use serde::de::{MapAccess, Visitor};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::metric::time_series::TimeSeries;
+use crate::utils::error::CoreDBError;
+
+#[derive(Debug)]
+/// Represents an time series map - a map of label-id to TimeSeries.
+pub struct TimeSeriesMap {
+  time_series_map: DashMap<u32, Arc<RwLock<TimeSeries>>>,
+}
+
+impl TimeSeriesMap {
+  /// Creates a new inverted map.
+  pub fn new() -> Self {
+    TimeSeriesMap {
+      time_series_map: DashMap::new(),
+    }
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.time_series_map.is_empty()
+  }
+
+  pub fn get_time_series(&self, label_id: u32) -> Option<Arc<RwLock<TimeSeries>>> {
+    self
+      .time_series_map
+      .get(&label_id)
+      .map(|time_series| time_series.clone())
+  }
+
+  pub fn append(&self, label_id: u32, time: u64, value: f64) -> Result<(), CoreDBError> {
+    // Access or insert the metric point for the given label id, ensuring thread-safe operation.
+    let arc_rwlock_ts = self
+      .time_series_map
+      .entry(label_id)
+      .or_default()
+      .value()
+      .clone();
+
+    // Acquire a write lock on the time series and append the metric point.
+    // The scope of the write lock is minimized to the append operation only.
+    {
+      let mut ts = arc_rwlock_ts.write().unwrap(); // Lock is acquired here.
+      ts.append(time, value);
+    } // Lock is automatically released here as pl goes out of scope.
+
+    Ok(())
+  }
+}
+
+/// Custom Serialize for TimeSeriesMap
+impl Serialize for TimeSeriesMap {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let map = &self.time_series_map;
+    let mut map_ser = serializer.serialize_map(Some(map.len()))?;
+    for entry in map.iter() {
+      let key = entry.key();
+      let value_lock = entry.value().read().unwrap();
+      map_ser.serialize_entry(&key, &*value_lock)?;
+    }
+    map_ser.end()
+  }
+}
+
+/// Custom Deserialize for TimeSeriesMap
+impl<'de> Deserialize<'de> for TimeSeriesMap {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    deserializer.deserialize_map(TimeSeriesMapVisitor)
+  }
+}
+
+struct TimeSeriesMapVisitor;
+
+impl<'de> Visitor<'de> for TimeSeriesMapVisitor {
+  type Value = TimeSeriesMap;
+
+  fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str("a map of u32 to Arc<RwLock<TimeSeries>>")
+  }
+
+  fn visit_map<M>(self, mut access: M) -> Result<TimeSeriesMap, M::Error>
+  where
+    M: MapAccess<'de>,
+  {
+    let dash_map = DashMap::new();
+
+    while let Some((key, value)) = access.next_entry::<u32, TimeSeries>()? {
+      dash_map.insert(key, Arc::new(RwLock::new(value)));
+    }
+
+    Ok(TimeSeriesMap {
+      time_series_map: dash_map,
+    })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::utils::sync::thread;
+
+  #[test]
+  fn test_parallel_append() {
+    let time_series_map = Arc::new(TimeSeriesMap::new());
+
+    // New inverted map should be empty.
+    assert!(time_series_map.is_empty());
+
+    let label_id = 1; // Using a single label ID for simplicity.
+
+    // Spawn 100 threads to append metrics (1 to 100).
+    let mut handles = vec![];
+    for i in 1..=100 {
+      let time_series_map = time_series_map.clone();
+      let handle = thread::spawn(move || {
+        time_series_map
+          .append(label_id, i, i as f64)
+          .expect("Could not append to time series map");
+      });
+      handles.push(handle);
+    }
+
+    // Wait for all threads to complete.
+    for handle in handles {
+      handle.join().unwrap();
+    }
+
+    // Retrieve and check the TimeSeries.
+    let time_series_arc = time_series_map.get_time_series(label_id).unwrap();
+    let time_series = time_series_arc.read().unwrap();
+
+    let time_series_vec = time_series.flatten();
+
+    // Ensure the list contains 100 metric points.
+    assert_eq!(time_series_vec.len(), 100);
+
+    // Ensure the list is sorted
+    let mut last_time = 0;
+    for metric_point in time_series_vec {
+      let curr_time = metric_point.get_time();
+      assert!(
+        curr_time > last_time,
+        "The list is not sorted. Found {} after {}",
+        curr_time,
+        last_time
+      );
+      last_time = curr_time;
+    }
+  }
+
+  #[test]
+  fn serialize_and_deserialize_inverted_map() {
+    let time_series_map = TimeSeriesMap::new();
+
+    // Setup - Insert some data into the TimeSeriesMap.
+    let mut time_series = TimeSeries::new();
+    time_series.append(1, 1_f64);
+    time_series.append(2, 2_f64);
+    time_series.append(3, 3_f64);
+
+    time_series_map
+      .time_series_map
+      .insert(1, Arc::new(RwLock::new(time_series)));
+
+    // Serialize the InvertedMap
+    let serialized =
+      serde_json::to_string(&time_series_map).expect("Failed to serialize InvertedMap");
+
+    // Deserialize the InvertedMap
+    let deserialized: TimeSeriesMap =
+      serde_json::from_str(&serialized).expect("Failed to deserialize InvertedMap");
+
+    // Verify that deserialized data matches original
+    let deserialized_time_series = deserialized.time_series_map.get(&1).unwrap();
+    let deserialized_time_series = &*deserialized_time_series.read().unwrap();
+
+    let deserialized_time_series_vec = deserialized_time_series.flatten();
+    assert_eq!(deserialized_time_series_vec.first().unwrap().get_time(), 1);
+    assert_eq!(deserialized_time_series_vec.get(1).unwrap().get_time(), 2);
+    assert_eq!(deserialized_time_series_vec.get(2).unwrap().get_time(), 3);
+  }
+}

--- a/coredb/src/utils/custom_serde.rs
+++ b/coredb/src/utils/custom_serde.rs
@@ -1,33 +1,6 @@
 // This code is licensed under Elastic License 2.0
 // https://www.elastic.co/licensing/elastic-license
 
-/// Custom serde serialize and deserialize implementation for RwLock.
-pub mod rwlock_serde {
-  use crate::utils::sync::RwLock;
-  use serde::de::Deserializer;
-  use serde::ser::Serializer;
-  use serde::{Deserialize, Serialize};
-
-  /// Serialize the type wrapped in RwLock.
-  pub fn serialize<S, T>(val: &RwLock<T>, s: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-    T: Serialize,
-  {
-    let inner = &*val.read().unwrap();
-    T::serialize(inner, s)
-  }
-
-  /// Deserialize the type and wrap it in RwLock.
-  pub fn deserialize<'de, D, T>(d: D) -> Result<RwLock<T>, D::Error>
-  where
-    D: Deserializer<'de>,
-    T: Deserialize<'de>,
-  {
-    Ok(RwLock::new(T::deserialize(d)?))
-  }
-}
-
 /// Custom serde serialize and deserialize implementation for Arc<RwLock>.
 pub mod arc_rwlock_serde {
   use crate::utils::sync::{Arc, RwLock};


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
- Simplify locking for metrics. Created a new TimeSeriesMap, which locks the values. The TimeSeries and TimeSeriesBlock do not use any locks.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
