### PR TITLE
Set the number of threads in tokio runtime

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,7 +15,7 @@ lapin = "2.3.1"
 lazy_static = "1"
 log = "0.4.19"
 mime = "0.3.16"
-mockall = "*"
+num_cpus = "1.13"
 openai-api-rs = "4.0.1"
 rabbitmq-stream-client = { git = "https://github.com/rabbitmq/rabbitmq-stream-rust-client", rev = "203d1a11fb29665e9385741df89b325a1deb3bff" }
 serde = { version = "1.0", features = ["derive"] }
@@ -41,6 +41,7 @@ features = [
 [dev-dependencies]
 assert_cmd = "*"
 cmd_lib = "*"
+mockall = "*"
 tower = { version = "*", features = ["util"] }
 tempdir = "*"
 test-case = "*"


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Explicitly set the number of threads to be used by tokio runtime. This is useful for perf tests, as well as tuning this number for a specific hardware in hosted environment. 


## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
