### PR TITLE
Use notify/await for commit thread instead of periodic sleep

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -7,14 +7,13 @@ index_dir_path = "data"
 
 # Index configuration.
 default_index_name = ".default"
-segment_size_threshold_megabytes = 256
+segment_size_threshold_megabytes = 16
 memory_budget_megabytes = 1024
 retention_days = 30
 
 [server]
 port = 3000
 host = "0.0.0.0"
-commit_interval_in_seconds = 30
 timestamp_key = "date"
 labels_key = "labels"
 use_rabbitmq = "no"             # specifies whether to write incoming messages to rabbitmq

--- a/config/default.toml
+++ b/config/default.toml
@@ -7,7 +7,7 @@ index_dir_path = "data"
 
 # Index configuration.
 default_index_name = ".default"
-segment_size_threshold_megabytes = 16
+segment_size_threshold_megabytes = 256
 memory_budget_megabytes = 1024
 retention_days = 30
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,6 +8,7 @@ axum = { version = "0.7.3", features = ["macros"] }
 cfg-if = "1.0"
 chrono = "0.4.31"
 config = "0.13.3"
+coredb = { path = "../coredb" }
 dhat = "0.3.2"
 env_logger = "0.10"
 hyper = { version = "1.1.0", features = ["full"] }
@@ -21,12 +22,12 @@ rabbitmq-stream-client = { git = "https://github.com/rabbitmq/rabbitmq-stream-ru
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1"
-coredb = { path = "../coredb" }
 tokio = { version = "1", features = ["full"] }
-tokio-stream = "0.1.14"
+tokio-executor = "0.1.10"
 tokio-executor-trait = "2.1.1"
 tokio-reactor-trait = "1.1.0"
 tokio-retry = "0.3"
+tokio-stream = "0.1.14"
 tower-http = { version = "0.5.0", features = ["trace"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/server/src/utils/settings.rs
+++ b/server/src/utils/settings.rs
@@ -10,7 +10,6 @@ const DEFAULT_CONFIG_FILE_NAME: &str = "default.toml";
 #[derive(Debug, Deserialize)]
 /// Settings for infino server.
 pub struct ServerSettings {
-  commit_interval_in_seconds: u32,
   port: u16,
   host: String,
   timestamp_key: String,
@@ -19,11 +18,6 @@ pub struct ServerSettings {
 }
 
 impl ServerSettings {
-  /// Get the commit interval in seconds.
-  pub fn get_commit_interval_in_seconds(&self) -> u32 {
-    self.commit_interval_in_seconds
-  }
-
   /// Get the port.
   pub fn get_port(&self) -> u16 {
     self.port
@@ -137,7 +131,6 @@ mod tests {
 
     // Check server settings.
     let server_settings = settings.get_server_settings();
-    assert_eq!(server_settings.get_commit_interval_in_seconds(), 30);
     assert_eq!(server_settings.get_port(), 3000);
     assert_eq!(server_settings.get_host(), "0.0.0.0");
     assert_eq!(server_settings.get_timestamp_key(), "date");


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Instead of periodic sleep, the commit threads waits to be notified for the next commit. An append or a shutdown operation triggers a notification.

This improves the shutdown experience where a shutdown is triggered immediately after Ctrl-C. Also, this optimizes the time between two successive commits (they will be spread apart where there are no appends happening, and will be close together when the volume of appends is large).

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
