### PR TITLE
nit: update a comment

### DIFF
--- a/coredb/src/lib.rs
+++ b/coredb/src/lib.rs
@@ -194,9 +194,7 @@ impl CoreDB {
       .await
   }
 
-  /// Commit the index to disk. If the flag sync_after_commit is set to true,
-  /// the directory is sync'd immediately instead of relying on the OS to do so,
-  /// hence this flag is usually set to true only in tests.
+  /// Commit the index to disk.
   pub async fn commit(&self) -> Result<(), CoreDBError> {
     self
       .index_map


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Nit: update a comment to avoid confusion. We no longer support sync_after_write flag since moving to object_store.

