### PR TITLE
Always import locks from crate::utils::sync, instead of directly importing from std::sync

### DIFF
--- a/coredb/src/log/inverted_map.rs
+++ b/coredb/src/log/inverted_map.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::sync::{Arc, RwLock};
 
 use dashmap::DashMap;
 use serde::de::{MapAccess, Visitor};
@@ -8,6 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::log::postings_list::PostingsList;
 use crate::utils::error::CoreDBError;
+use crate::utils::sync::{Arc, RwLock};
 
 #[derive(Debug)]
 /// Represents an inverted index - a map of term-id to PostingsList.

--- a/coredb/src/metric/time_series_map.rs
+++ b/coredb/src/metric/time_series_map.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::sync::{Arc, RwLock};
 
 use dashmap::DashMap;
 use serde::de::{MapAccess, Visitor};
@@ -8,6 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::metric::time_series::TimeSeries;
 use crate::utils::error::CoreDBError;
+use crate::utils::sync::{Arc, RwLock};
 
 #[derive(Debug)]
 /// Represents an time series map - a map of label-id to TimeSeries.

--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -517,7 +517,7 @@ impl Default for Segment {
 
 #[cfg(test)]
 mod tests {
-  use std::sync::{Arc, RwLock};
+  use crate::utils::sync::{Arc, RwLock};
 
   use chrono::Utc;
   use log::error;


### PR DESCRIPTION


<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Always import locks from crate::utils::sync, instead of directly importing from std::sync

This allows to move over all the locks to another strategy, such as using parking_lot crate, quickly.

