### PR TITLE
Use RwLock from parking_lot crate, instead of from std::sync

### DIFF
--- a/coredb/Cargo.toml
+++ b/coredb/Cargo.toml
@@ -22,6 +22,7 @@ google-cloud-storage = "0.15.0"
 lazy_static = "1.4.0"
 log = "0.4"
 object_store = { version = "0.9.0", features = ["aws", "gcp", "azure"] }
+parking_lot = "0.12"
 pest = { git = "http://github.com/infinohq/pest", branch = "master" }
 pest_derive = "2.7.6"
 regex = "1.10.3"

--- a/coredb/src/log/inverted_map.rs
+++ b/coredb/src/log/inverted_map.rs
@@ -46,7 +46,7 @@ impl InvertedMap {
     // Acquire a write lock on the postings list and append the log message id.
     // The scope of the write lock is minimized to the append operation only.
     {
-      let mut pl = arc_rwlock_pl.write().unwrap(); // Lock is acquired here.
+      let mut pl = arc_rwlock_pl.write(); // Lock is acquired here.
       pl.append(log_message_id)?;
     } // Lock is automatically released here as pl goes out of scope.
 
@@ -76,7 +76,7 @@ impl Serialize for InvertedMap {
     let mut map_ser = serializer.serialize_map(Some(map.len()))?;
     for entry in map.iter() {
       let key = entry.key();
-      let value_lock = entry.value().read().unwrap();
+      let value_lock = entry.value().read();
       map_ser.serialize_entry(&key, &*value_lock)?;
     }
     map_ser.end()
@@ -151,7 +151,7 @@ mod tests {
 
     // Retrieve and check the PostingsList.
     let postings_list_arc = inverted_map.get_postings_list(term_id).unwrap();
-    let postings_list = postings_list_arc.read().unwrap();
+    let postings_list = postings_list_arc.read();
 
     let postings_list_vec = postings_list.flatten();
 
@@ -200,7 +200,7 @@ mod tests {
 
     // Verify that deserialized data matches original
     let deserialized_postings_list = deserialized.inverted_map.get(&1).unwrap();
-    let deserialized_postings_list = &*deserialized_postings_list.read().unwrap();
+    let deserialized_postings_list = &*deserialized_postings_list.read();
 
     let deserialized_postings_list_vec = deserialized_postings_list.flatten();
     assert_eq!(deserialized_postings_list_vec, vec![1, 2, 3]);

--- a/coredb/src/metric/time_series.rs
+++ b/coredb/src/metric/time_series.rs
@@ -340,8 +340,8 @@ mod tests {
         for _ in 0..num_metric_points_per_thread {
           let time = rng.gen_range(0..10000);
           let dp = MetricPoint::new(time, 1.0);
-          ts_arc.write().unwrap().append(time, 1.0);
-          expected_arc.write().unwrap().push(dp);
+          ts_arc.write().append(time, 1.0);
+          expected_arc.write().push(dp);
         }
       });
       handles.push(handle);
@@ -351,7 +351,7 @@ mod tests {
       handle.join().unwrap();
     }
 
-    let ts = &*ts.read().unwrap();
+    let ts = &*ts.read();
     let compressed_blocks = ts.get_compressed_blocks();
     let last_block = ts.get_last_block();
     let initial_times = ts.get_initial_times();
@@ -361,7 +361,7 @@ mod tests {
     assert_eq!(initial_times.len(), num_blocks);
 
     let received = ts.get_metrics(0, u64::MAX);
-    (*expected.write().unwrap()).sort();
-    assert_eq!(*expected.read().unwrap(), received);
+    (*expected.write()).sort();
+    assert_eq!(*expected.read(), received);
   }
 }

--- a/coredb/src/metric/time_series_block.rs
+++ b/coredb/src/metric/time_series_block.rs
@@ -201,8 +201,8 @@ mod tests {
         for _ in 0..num_metric_points_per_thread {
           let time = rng.gen_range(0..10000);
           let dp = MetricPoint::new(time, 1.0);
-          tsb_arc.write().unwrap().append(time, 1.0).unwrap();
-          (*(expected_arc.write().unwrap())).push(dp);
+          tsb_arc.write().append(time, 1.0).unwrap();
+          (*(expected_arc.write())).push(dp);
         }
       });
       handles.push(handle);
@@ -213,15 +213,12 @@ mod tests {
     }
 
     // Sort the expected values, as the metric points should be appended in sorted order.
-    (*expected.write().unwrap()).sort();
+    (*expected.write()).sort();
 
-    assert_eq!(
-      *expected.read().unwrap(),
-      *tsb.read().unwrap().metric_points
-    );
+    assert_eq!(*expected.read(), *tsb.read().metric_points);
 
     // If we append more than BLOCK_SIZE, it should result in an error.
-    let retval = tsb.write().unwrap().append(1000, 1000.0);
+    let retval = tsb.write().append(1000, 1000.0);
     assert!(retval.is_err());
   }
 }

--- a/coredb/src/metric/time_series_map.rs
+++ b/coredb/src/metric/time_series_map.rs
@@ -46,7 +46,7 @@ impl TimeSeriesMap {
     // Acquire a write lock on the time series and append the metric point.
     // The scope of the write lock is minimized to the append operation only.
     {
-      let mut ts = arc_rwlock_ts.write().unwrap(); // Lock is acquired here.
+      let mut ts = arc_rwlock_ts.write(); // Lock is acquired here.
       ts.append(time, value);
     } // Lock is automatically released here as pl goes out of scope.
 
@@ -70,7 +70,7 @@ impl Serialize for TimeSeriesMap {
     let mut map_ser = serializer.serialize_map(Some(map.len()))?;
     for entry in map.iter() {
       let key = entry.key();
-      let value_lock = entry.value().read().unwrap();
+      let value_lock = entry.value().read();
       map_ser.serialize_entry(&key, &*value_lock)?;
     }
     map_ser.end()
@@ -145,7 +145,7 @@ mod tests {
 
     // Retrieve and check the TimeSeries.
     let time_series_arc = time_series_map.get_time_series(label_id).unwrap();
-    let time_series = time_series_arc.read().unwrap();
+    let time_series = time_series_arc.read();
 
     let time_series_vec = time_series.flatten();
 
@@ -190,7 +190,7 @@ mod tests {
 
     // Verify that deserialized data matches original
     let deserialized_time_series = deserialized.time_series_map.get(&1).unwrap();
-    let deserialized_time_series = &*deserialized_time_series.read().unwrap();
+    let deserialized_time_series = &*deserialized_time_series.read();
 
     let deserialized_time_series_vec = deserialized_time_series.flatten();
     assert_eq!(deserialized_time_series_vec.first().unwrap().get_time(), 1);

--- a/coredb/src/segment_manager/search_logs.rs
+++ b/coredb/src/segment_manager/search_logs.rs
@@ -48,7 +48,7 @@ impl Segment {
         }
       };
 
-      let postings_list = postings_list.read().unwrap();
+      let postings_list = postings_list.read();
 
       let initial_values = postings_list.get_initial_values().clone();
       initial_values_list.push(initial_values);

--- a/coredb/src/segment_manager/search_metrics.rs
+++ b/coredb/src/segment_manager/search_metrics.rs
@@ -68,7 +68,7 @@ impl Segment {
           .get_time_series(*label_id)
           .unwrap()
           .clone();
-        let ts = &*arc_ts.read().unwrap();
+        let ts = &*arc_ts.read();
         ts.get_metrics(range_start_time, range_end_time)
       }
       None => Vec::new(),

--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -667,12 +667,12 @@ mod tests {
       .unwrap();
     {
       let ts = ts.clone();
-      let ts = &*ts.read().unwrap();
+      let ts = &*ts.read();
       let other_label_ts = from_disk_segment
         .time_series_map
         .get_time_series(other_label_id)
         .unwrap();
-      let other_label_ts = other_label_ts.read().unwrap();
+      let other_label_ts = other_label_ts.read();
       assert!(ts.eq(&other_label_ts));
       assert_eq!(ts.get_compressed_blocks().len(), 0);
       assert_eq!(ts.get_initial_times().len(), 1);
@@ -814,7 +814,7 @@ mod tests {
           segment_arc
             .append_metric_point("metric_name", &label_map, dp.get_time(), dp.get_value())
             .unwrap();
-          expected_arc.write().unwrap().push(dp);
+          expected_arc.write().push(dp);
         }
       });
       handles.push(handle);
@@ -829,7 +829,7 @@ mod tests {
     assert!(segment.metadata.get_start_time() >= start_time);
     assert!(segment.metadata.get_end_time() <= end_time);
 
-    let mut expected = (*expected.read().unwrap()).clone();
+    let mut expected = (*expected.read()).clone();
 
     let mut labels = HashMap::new();
     labels.insert("label1".to_owned(), "value1".to_owned());

--- a/coredb/src/utils/custom_serde.rs
+++ b/coredb/src/utils/custom_serde.rs
@@ -16,7 +16,7 @@ pub mod arc_rwlock_serde {
     T: Serialize,
   {
     let cloned = val.clone();
-    let inner = &cloned.read().unwrap();
+    let inner = &cloned.read();
     T::serialize(inner, s)
   }
 

--- a/coredb/src/utils/sync.rs
+++ b/coredb/src/utils/sync.rs
@@ -16,7 +16,7 @@ pub(crate) use loom::thread;
 // https://github.com/tokio-rs/loom/blob/16e5e9a0e562cf754ced04ac1a82802b8e492178/src/rt/notify.rs#L113
 // Once this is fixed, we can use loom::sync::RwLock when configuration is loom (and use std::sync::RwLock
 // when the configuration isn't loom).
-pub(crate) use std::sync::RwLock;
+pub(crate) use parking_lot::RwLock;
 
 // Tokio Mutex and RwLock - needed when we need lock to be Send + Sync.
 pub(crate) use tokio::sync::Mutex as TokioMutex;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -305,7 +305,7 @@ fn main() {
 
   // If log level isn't set, set it to info.
   if env::var("RUST_LOG").is_err() {
-    env::set_var("RUST_LOG", "debug")
+    env::set_var("RUST_LOG", "info")
   }
 
   // Set up logging.


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Use RwLock from parking_lot crate, instead of from std::sync. Advantage of parking_lot - see 'Features' in
https://crates.io/crates/parking_lot

