### PR TITLE
feat: match phrase query support

### DIFF
--- a/coredb/src/log/log_message.rs
+++ b/coredb/src/log/log_message.rs
@@ -70,7 +70,7 @@ impl LogMessage {
     tokenize(&text, &mut tokens);
     terms.extend(tokens.into_iter().map(|s| s.to_string()));
 
-    // Each word in a field value goes with a perfix a of its field name, followed by ":".
+    // Each word in a field value goes with a prefix a of its field name, followed by ":".
     for field in &self.fields {
       let name = field.0;
       let mut values: Vec<&str> = Vec::new();

--- a/coredb/src/segment_manager/query_dsl.rs
+++ b/coredb/src/segment_manager/query_dsl.rs
@@ -12,7 +12,7 @@
 
 use crate::segment_manager::segment::Segment;
 use crate::utils::error::AstError;
-use crate::utils::tokenize::tokenize;
+use crate::utils::tokenize::{tokenize, FIELD_DELIMITER};
 
 use log::debug;
 use pest::iterators::{Pair, Pairs};
@@ -68,6 +68,7 @@ impl Segment {
       Rule::term_query => self.process_term_query(node).await,
       Rule::match_query => self.process_match_query(node).await,
       Rule::bool_query => self.process_bool_query(node).await,
+      Rule::match_phrase_query => self.process_match_phrase_query(node).await,
       _ => Err(AstError::UnsupportedQuery(format!(
         "Unsupported rule: {:?}",
         node.as_rule()
@@ -289,6 +290,68 @@ impl Segment {
     }
   }
 
+  /// Match Phrase Query Processor: https://opensearch.org/docs/latest/query-dsl/full-text/match-phrase/
+  async fn process_match_phrase_query(
+    &self,
+    root_node: &Pair<'_, Rule>,
+  ) -> Result<HashSet<u32>, AstError> {
+    let mut stack: VecDeque<Pair<Rule>> = VecDeque::new();
+    stack.push_back(root_node.clone());
+
+    let mut fieldname: Option<&str> = None;
+    let mut query_text: Option<&str> = None;
+
+    while let Some(node) = stack.pop_front() {
+      match node.as_rule() {
+        Rule::fieldname => {
+          if let Some(field) = node.into_inner().next() {
+            fieldname = Some(field.as_str());
+          }
+        }
+        Rule::match_phrase_string | Rule::query => {
+          query_text = node.into_inner().next().map(|v| v.as_str());
+        }
+        _ => {
+          for inner_node in node.into_inner() {
+            stack.push_back(inner_node);
+          }
+        }
+      }
+    }
+
+    if let Some(field) = fieldname {
+      if let Some(query_str) = query_text {
+        // Get the doc IDs for all the search
+        let search_result = self
+          .process_search(
+            self.analyze_query_text(query_str, Some(field), false).await,
+            "AND",
+          )
+          .await?;
+
+        let search_result_vec: Vec<_> = search_result.into_iter().collect();
+
+        // From the given document IDs, filter document ids which contain the exact phrase (in the given field)
+        // and return the specific document ids
+        let matching_document_ids = self.find_exact_phrase_matches(
+          &search_result_vec,
+          Some(field),
+          query_str.trim_matches('"'),
+        );
+
+        Ok(matching_document_ids)
+      } else {
+        Err(AstError::UnsupportedQuery(
+          "Query string is missing".to_string(),
+        ))
+      }
+    } else {
+      Err(AstError::UnsupportedQuery(
+        "Field name is missing".to_string(),
+      ))
+    }
+  }
+
   /// Prep the query terms for the search
   async fn analyze_query_text(
     &self,
@@ -311,7 +374,7 @@ impl Segment {
       .into_iter()
       .map(|term| {
         if let Some(field) = fieldname {
-          format!("{}~{}", field, term)
+          format!("{}{}{}", field, FIELD_DELIMITER, term)
         } else {
           term.to_owned()
         }
@@ -375,8 +438,10 @@ mod tests {
 
     let log_messages = [
       ("log 1", "this is a test log message"),
-      ("log 2", "this is another log message"),
-      ("log 3", "test log for different term"),
+      ("log 2", "this is another log message field1value"),
+      ("log 3 1", "test log for different term"),
+      ("log 4", "field1~field1value testing field name and value"),
+      ("log 5", "field1~field2value testing field name two value"),
     ];
 
     for (key, message) in log_messages.iter() {
@@ -562,11 +627,53 @@ mod tests {
         Ok(results) => {
           assert_eq!(
             results.len(),
-            1,
-            "There should be exactly 1 logs matching the query."
+            2,
+            "There should be exactly 2 logs matching the query."
           );
 
           assert!(results.iter().all(|log| log.get_text().contains("log")));
+        }
+        Err(err) => {
+          panic!("Error in search_logs: {:?}", err);
+        }
+      },
+      Err(err) => {
+        panic!("Error parsing query DSL: {:?}", err);
+      }
+    }
+  }
+
+  #[tokio::test]
+  async fn test_search_with_match_phrase_query() {
+    let segment = create_mock_segment();
+
+    let query_dsl_query = r#"{
+      "query": {
+        "match_phrase": {
+          "key": {
+            "query": "log 1"
+          }
+        }
+      }
+    }"#;
+
+    match QueryDslParser::parse(Rule::start, query_dsl_query) {
+      Ok(ast) => match segment.search_logs(&ast, 0, u64::MAX).await {
+        Ok(results) => {
+          assert_eq!(
+            results.len(),
+            1,
+            "There should be exactly 1 log matching the query."
+          );
+
+          for log in results {
+            let key_field_value = log.get_fields().get("key");
+
+            assert!(
+              key_field_value.map_or(false, |value| value.contains("log 1")),
+              "Each log should have 'key' field containing 'log 1'."
+            );
+          }
         }
         Err(err) => {
           panic!("Error in search_logs: {:?}", err);

--- a/coredb/src/segment_manager/query_dsl.rs
+++ b/coredb/src/segment_manager/query_dsl.rs
@@ -13,8 +13,8 @@
 use crate::segment_manager::segment::Segment;
 use crate::utils::error::AstError;
 
-use crate::utils::tokenize::{tokenize, FIELD_DELIMITER};
 use crate::utils::error::SearchLogsError;
+use crate::utils::tokenize::{tokenize, FIELD_DELIMITER};
 
 use futures::StreamExt;
 use log::debug;

--- a/coredb/src/segment_manager/query_dsl_grammar.pest
+++ b/coredb/src/segment_manager/query_dsl_grammar.pest
@@ -131,9 +131,9 @@ match_bool_prefix        = { (analyzer | fuzziness | fuzzy_rewrite | fuzzy_trans
 
 // Match Phrase Queries: https://opensearch.org/docs/latest/query-dsl/full-text/match-phrase/
 match_phrase_query  = { start_brace ~ quote ~ "match_phrase" ~ quote ~ colon ~ match_phrase_search ~ end_brace }
-match_phrase_search = { start_brace ~ fieldname ~ colon ~ match_phrase_array ~ end_brace }
-match_phrase_array  = { start_brace ~ query ~ (comma ~ match_phrase)* ~ end_brace }
-match_phrase        = { (analyzer | slop | zero_terms_query) }
+match_phrase_search = { start_brace ~ fieldname ~ colon ~ (match_phrase_string | match_phrase_array) ~ end_brace }
+match_phrase_array  = { start_brace ~ query ~ (comma ~ match_phrase_terms)* ~ end_brace }
+match_phrase_terms  = { (analyzer | slop | zero_terms_query) }
 
 // Match Phrase Queries: https://opensearch.org/docs/latest/query-dsl/full-text/match-phrase/
 match_phrase_prefix_query  = { start_brace ~ quote ~ "match_phrase_prefix" ~ quote ~ colon ~ match_phrase_prefix_search ~ end_brace }
@@ -417,6 +417,7 @@ linear_ring                         = { start_bracket ~ (geo_coordinate ~ (comma
 lt                                  = { quote ~ "lt" ~ quote ~ colon ~ (number | date) }
 lte                                 = { quote ~ "lte" ~ quote ~ colon ~ (number | date) }
 map_script                          = { quote ~ "map_script" ~ quote ~ colon ~ script_clause }
+match_phrase_string                 = { string }
 match_string                        = { string }
 max_boost                           = { quote ~ "max_boost" ~ quote ~ colon ~ float }
 max_determinized_states             = { quote ~ "max_determinized_states" ~ quote ~ colon ~ integer }


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
- Added support for the [match phrase](https://opensearch.org/docs/latest/query-dsl/full-text/match-phrase/) query support

## How does this PR work?
- Included support for the match phrase query:
  - Modified the grammar to enable `match_phrase_array`, and its terms.
  - Process search such that we get only those doc_ids with all the terms`fieldname~field_element`, where `field_element`(s) are obtained from tokenised `query_text`.
  - Added a new method to `segment` to filter `doc_ids` with exact phrase matches, and utilized it for the processing here.

## Refer to a related PR or issue link
- N.A.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
