### PR TITLE
Prometheus-formatted responses to PromQL queries

### DIFF
--- a/coredb/src/metric/metric_point.rs
+++ b/coredb/src/metric/metric_point.rs
@@ -3,12 +3,13 @@
 
 use approx::abs_diff_eq;
 use chrono::{DateTime, Datelike, LocalResult, TimeZone, Timelike, Utc};
-use serde::{Deserialize, Serialize};
+use serde::ser::SerializeTuple;
+use serde::{Deserialize, Serialize, Serializer};
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 
 /// Represents a metric point in time series.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize)]
 pub struct MetricPoint {
   /// Timestamp from epoch.
   time: u64,
@@ -87,6 +88,18 @@ impl MetricPoint {
   // Extracts the hour from the timestamp
   pub fn hour(&self) -> u32 {
     self.datetime().hour()
+  }
+}
+
+impl Serialize for MetricPoint {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut tuple_serializer = serializer.serialize_tuple(2)?;
+    tuple_serializer.serialize_element(&self.time)?;
+    tuple_serializer.serialize_element(&self.value)?;
+    tuple_serializer.end()
   }
 }
 

--- a/coredb/src/request_manager/promql_object.rs
+++ b/coredb/src/request_manager/promql_object.rs
@@ -6,6 +6,7 @@
 use super::promql_time_series::PromQLTimeSeries;
 use crate::metric::metric_point::MetricPoint;
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -100,18 +101,27 @@ pub enum FunctionOperator {
   PresentOverTime,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum PromQLObjectType {
+  #[serde(rename = "scalar")]
   Scalar,
+
+  #[serde(rename = "vector")]
   InstantVector,
+
+  #[serde(rename = "matrix")]
   RangeVector,
-  Undefined,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PromQLObject {
+  #[serde(rename = "result")]
   vector: Vec<PromQLTimeSeries>,
+
+  #[serde(skip_serializing)]
   scalar: f64,
+
+  #[serde(rename = "resultType")]
   object_type: PromQLObjectType,
 }
 
@@ -121,7 +131,7 @@ impl PromQLObject {
     PromQLObject {
       vector: Vec::new(),
       scalar: 0.0,
-      object_type: PromQLObjectType::Undefined,
+      object_type: PromQLObjectType::InstantVector,
     }
   }
 
@@ -203,6 +213,11 @@ impl PromQLObject {
   pub fn set_vector(&mut self, vector: Vec<PromQLTimeSeries>) {
     self.vector = vector;
     self.update_object_type();
+  }
+
+  /// Getter for object type
+  pub fn get_object_type(&self) -> &PromQLObjectType {
+    &self.object_type
   }
 
   /// Getter for scalar


### PR DESCRIPTION
## What does this PR do?
- Return PromQL formattted responses to PromQL queries.

## How does this PR work? (optional)
- Expose the internal PromQLObject to the main server app.
- Implements custom serialization on PromQLObject (and underlying PromQLTimeSeries and MetricPoint structs)

## Refer to a related PR or issue link
[- (Related PR or issue)](https://github.com/infinohq/infino/issues/112)

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
