### PR TITLE
feat: trie in segment, and support prefix query

### DIFF
--- a/coredb/src/log/log_message.rs
+++ b/coredb/src/log/log_message.rs
@@ -67,6 +67,8 @@ impl LogMessage {
   // TODO: This function could be optimized to reduce string operations. We process
   // the strings dynamically (e.g., changing case, adding FIELD_DELIMITER, etc) so it
   // it isn't as straightforward.
+  //
+  // Note: The case information for the text is also being lost here.
   pub fn get_terms(&self) -> Vec<String> {
     let text = self.text.to_lowercase();
     let mut terms: Vec<String> = Vec::new();

--- a/coredb/src/request_manager/query_dsl_grammar.pest
+++ b/coredb/src/request_manager/query_dsl_grammar.pest
@@ -93,9 +93,9 @@ id_element = { string }
 
 // Prefix Queries: https://opensearch.org/docs/latest/query-dsl/term/prefix/
 prefix_query  = { start_brace ~ quote ~ "prefix" ~ quote ~ colon ~ prefix_search ~ end_brace }
-prefix_search = { start_brace ~ (field | (fieldname ~ colon ~ prefix_array)) ~ end_brace }
-prefix_array  = { start_brace ~ (prefix ~ (comma ~ prefix)*)? ~ end_brace }
-prefix        = { (field | case_insensitive | rewrite) }
+prefix_search = { start_brace ~ fieldname ~ colon ~ (prefix_string | prefix_array) ~ end_brace }
+prefix_array  = { start_brace ~ value ~ (comma ~ prefix_terms)* ~ end_brace }
+prefix_terms  = { (case_insensitive | rewrite) }
 
 // Regexp Queries: https://opensearch.org/docs/latest/query-dsl/term/regexp/
 regexp_query  = { start_brace ~ quote ~ "regexp" ~ quote ~ colon ~ regexp_search ~ end_brace }
@@ -484,6 +484,7 @@ post_tags                    = { quote ~ "post_tags" ~ quote ~ colon ~ array_of_
 pre_tags                     = { quote ~ "pre_tags" ~ quote ~ colon ~ array_of_strings }
 precision                    = { quote ~ "precision" ~ quote ~ colon ~ integer }
 prefix_length                = { quote ~ "prefix_length" ~ quote ~ colon ~ non_negative_integer }
+prefix_string                = { string }
 query                        = { quote ~ "query" ~ quote ~ colon ~ string }
 query_array                  = { start_bracket ~ (query_root ~ (comma ~ query_root)*)? ~ end_bracket }
 quote_analyzer               = { quote ~ "quote_analyzer" ~ quote ~ colon ~ string }

--- a/coredb/src/segment_manager/search_logs.rs
+++ b/coredb/src/segment_manager/search_logs.rs
@@ -538,7 +538,7 @@ impl Segment {
   /// * `prefix_text_str` - The exact prefix text string to match.
   /// * `case_insensitive` - A boolean flag indicating whether the search is case-insensitive.
   ///
-  pub async fn retrieve_doc_ids_with_prefix_phrase(
+  pub async fn get_doc_ids_with_prefix_phrase(
     &self,
     prefix_phrase_terms: Vec<String>,
     field: &str,

--- a/coredb/src/segment_manager/search_logs.rs
+++ b/coredb/src/segment_manager/search_logs.rs
@@ -535,6 +535,7 @@ impl Segment {
     doc_ids: &[u32],
     field_name: &str,
     prefix_text: &str,
+    case_insensitive: bool,
   ) -> Vec<u32> {
     doc_ids
       .iter()
@@ -545,7 +546,15 @@ impl Segment {
             .get_fields()
             .get(field_name)
             .and_then(|field_value| {
-              if field_value.starts_with(prefix_text) {
+              let value_to_compare = if case_insensitive {
+                field_value.to_lowercase()
+              } else {
+                field_value.to_string()
+              };
+
+              if case_insensitive && value_to_compare.starts_with(&prefix_text.to_lowercase())
+                || !case_insensitive && value_to_compare.starts_with(prefix_text)
+              {
                 Some(log_id)
               } else {
                 None

--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -207,7 +207,7 @@ impl Segment {
     // Increment the number of log messages appended so far, and get the id for this log message.
     let log_message_id = self.metadata.fetch_increment_log_message_count();
 
-    let trie = Arc::clone(&self.trie);
+    let trie = self.trie.clone();
 
     // Update the inverted map.
     terms.into_iter().for_each(|term| {

--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -196,7 +196,7 @@ impl Segment {
     terms.into_iter().for_each(|term| {
       let term_id = *self
         .terms
-        .entry(term.to_owned())
+        .entry(term.clone())
         .or_insert_with(|| self.metadata.fetch_increment_term_count());
 
       self

--- a/coredb/src/utils/mod.rs
+++ b/coredb/src/utils/mod.rs
@@ -13,3 +13,4 @@ pub mod request;
 pub mod sync;
 pub mod time;
 pub mod tokenize;
+pub mod trie;

--- a/coredb/src/utils/trie.rs
+++ b/coredb/src/utils/trie.rs
@@ -1,0 +1,285 @@
+use std::collections::HashMap;
+
+use super::tokenize::FIELD_DELIMITER;
+
+/// TrieNode represents a node in the Trie data structure.
+#[derive(Default, Debug)]
+struct TrieNode {
+  /// Indicates whether the node marks the end of a word in the Trie.
+  is_end_of_word: bool,
+
+  /// Stores the children nodes of the current node, indexed by character.
+  children: HashMap<char, TrieNode>,
+}
+
+/// Trie is a trie data structure supporting insertion, containment check, and prefix search.
+#[derive(Default, Debug)]
+pub struct Trie {
+  root: TrieNode,
+}
+
+#[allow(clippy::only_used_in_recursion)]
+impl Trie {
+  pub fn new() -> Self {
+    Trie {
+      root: TrieNode::default(),
+    }
+  }
+
+  /// Inserts a word into the Trie.
+  pub fn insert(&mut self, word: &str) {
+    let mut current_node = &mut self.root;
+
+    // Traverse the Trie, creating nodes for each character in the word.
+    for c in word.chars() {
+      current_node = current_node.children.entry(c).or_default();
+    }
+
+    // Mark the end of the word in the Trie.
+
+    current_node.is_end_of_word = true;
+  }
+
+  /// Checks if a word is contained in the Trie.
+  pub fn contains(&self, word: &str) -> bool {
+    let mut current_node = &self.root;
+
+    for c in word.chars() {
+      match current_node.children.get(&c) {
+        Some(node) => current_node = node,
+        None => return false,
+      }
+    }
+
+    current_node.is_end_of_word
+  }
+
+  /// Retrieves all terms in the Trie with a given prefix.
+  ///
+  /// # Arguments
+  ///
+  /// - `prefix`: The prefix to search for in the Trie.
+  /// - `case_insensitive`: A flag indicating whether the search should be case-insensitive.
+  ///
+  /// # Logic:
+  ///
+  /// - If `case_insensitive` is false:
+  ///   - Perform a regular search, traversing the Trie based on the characters in the prefix.
+  ///
+  /// - If `case_insensitive` is true:
+  ///   - Check if the `prefix` contains FIELD_DELIMITER.
+  ///     - If yes:
+  ///       - Perform a case-sensitive search until the FIELD_DELIMITER is encountered, because fields cannot be case-insensitive
+  ///       - After encountering FIELD_DELIMITER, the search becomes case-insensitive for the remaining characters.
+  ///     - If no:
+  ///       - Perform a case-insensitive search for the entire prefix.
+  ///
+  pub fn get_terms_with_prefix(&self, prefix: &str, case_insensitive: bool) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut current_node = &self.root;
+
+    if case_insensitive {
+      // Check if the prefix contains FIELD_DELIMITER for case-insensitive search
+      if let Some(index) = prefix.chars().position(|c| c == FIELD_DELIMITER) {
+        // Traverse the trie until the FIELD_DELIMITER
+        for c in prefix[..=index].chars() {
+          match current_node.children.get(&c) {
+            Some(node) => current_node = node,
+            None => return result,
+          }
+        }
+
+        // Call search_case_insensitive_prefix with remaining characters post FIELD_DELIMITER
+        self.search_case_insensitive_prefix(
+          current_node,
+          &prefix[index + 1..],
+          &prefix[..=index],
+          &mut result,
+        );
+
+        return result;
+      } else {
+        // If Delimiter is not present, then perform regular prefix search
+        self.search_case_insensitive_prefix(current_node, prefix, "", &mut result);
+
+        return result;
+      }
+    }
+
+    // If case_insensitive is false, perform a regular search
+    for c in prefix.chars() {
+      match current_node.children.get(&c) {
+        Some(node) => current_node = node,
+        None => return result,
+      }
+    }
+
+    // Directly call collect_terms_with_prefix for the remaining trie
+    self.collect_terms_with_prefix(current_node, prefix, &mut result);
+
+    result
+  }
+
+  /// Recursively searches the Trie for terms with a case-insensitive prefix.
+  ///
+  /// This method is specifically designed for case-insensitive searches until
+  /// the entire given prefix is traversed. It explores both lowercase and uppercase
+  /// paths in the Trie to accommodate case variations in the search prefix.
+  ///
+  /// # Arguments
+  ///
+  /// - `node`: The current TrieNode being traversed during recursion.
+  /// - `remaining_chars`: The remaining characters in the search prefix.
+  /// - `current_prefix`: The prefix accumulated during the recursive traversal.
+  /// - `result`: The vector to collect terms that match the case-insensitive prefix.
+
+  fn search_case_insensitive_prefix(
+    &self,
+    node: &TrieNode,
+    remaining_chars: &str,
+    current_prefix: &str,
+    result: &mut Vec<String>,
+  ) {
+    if remaining_chars.is_empty() {
+      // If no more characters in the prefix, collect terms with the current prefix.
+      self.collect_terms_with_prefix(node, current_prefix, result);
+      return;
+    }
+
+    let current_char = remaining_chars.chars().next().unwrap();
+
+    // Convert the current character to lowercase and uppercase for case-insensitive search.
+    let lowercase_char = current_char.to_ascii_lowercase();
+    let uppercase_char = current_char.to_ascii_uppercase();
+
+    // Check and traverse the Trie for both lowercase and uppercase characters.
+    if let Some(lowercase_node) = node.children.get(&lowercase_char) {
+      self.search_case_insensitive_prefix(
+        lowercase_node,
+        &remaining_chars[1..],
+        &(current_prefix.to_string() + &lowercase_char.to_string()),
+        result,
+      );
+    }
+
+    if let Some(uppercase_node) = node.children.get(&uppercase_char) {
+      self.search_case_insensitive_prefix(
+        uppercase_node,
+        &remaining_chars[1..],
+        &(current_prefix.to_string() + &uppercase_char.to_string()),
+        result,
+      );
+    }
+  }
+
+  /// Recursively collects all terms in the Trie with a given prefix.
+  fn collect_terms_with_prefix(&self, node: &TrieNode, prefix: &str, result: &mut Vec<String>) {
+    if node.is_end_of_word {
+      // If the node marks the end of a word, add it to the result.
+
+      result.push(prefix.to_string());
+    }
+
+    // Recursively traverse child nodes and collect terms with the updated prefix.
+    for (child_char, child_node) in &node.children {
+      // Skip collecting terms if the child_char is FIELD_DELIMITER.
+      if *child_char != FIELD_DELIMITER {
+        let mut next_prefix = prefix.to_string();
+        next_prefix.push(*child_char);
+        self.collect_terms_with_prefix(child_node, &next_prefix, result);
+      }
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// Helper function to assert that two vectors contain the same elements, regardless of order.
+  fn assert_contains_same_elements(actual: Vec<String>, expected: Vec<&str>) {
+    assert_eq!(actual.len(), expected.len(), "Vector lengths do not match");
+
+    for element in expected {
+      assert!(
+        actual.contains(&element.to_string()),
+        "Element {} not found in vector",
+        element
+      );
+    }
+  }
+
+  #[test]
+  fn test_insert_and_contains() {
+    let mut trie = Trie::new();
+
+    // Insert words into the trie
+    trie.insert("apple");
+    trie.insert("app");
+    trie.insert("banana");
+
+    // Test word containment
+    assert!(trie.contains("apple"));
+    assert!(trie.contains("app"));
+    assert!(trie.contains("banana"));
+
+    // Test non-existent words
+    assert!(!trie.contains("apricot"));
+    assert!(!trie.contains("ban"));
+  }
+
+  #[test]
+  fn test_prefix_search_case_sensitive() {
+    let mut trie = Trie::new();
+
+    // Insert words into the trie
+    trie.insert("apple");
+    trie.insert("aPple");
+    trie.insert("app");
+    trie.insert("banana");
+    trie.insert("apricot");
+    trie.insert("app~delimiter");
+
+    // Test prefix search
+    let result: Vec<String> = trie.get_terms_with_prefix("app", false);
+    let expected_result = vec!["app", "apple"];
+
+    assert_contains_same_elements(result, expected_result);
+  }
+
+  #[test]
+  fn test_prefix_search_case_insensitive() {
+    let mut trie = Trie::new();
+
+    // Insert words into the trie
+    trie.insert("apple");
+    trie.insert("app");
+    trie.insert("aPpLe");
+    trie.insert("banana");
+    trie.insert("apricot");
+
+    // Test case-insensitive prefix search
+    let result: Vec<String> = trie.get_terms_with_prefix("Ap", true);
+    let expected_result = vec!["app", "apple", "apricot", "aPpLe"];
+
+    assert_contains_same_elements(result, expected_result);
+  }
+
+  #[test]
+  fn test_prefix_search_case_insensitive_and_delimiter() {
+    let mut trie = Trie::new();
+
+    // Insert words into the trie with Delimiter
+    trie.insert("fruit~apple");
+    trie.insert("FRUIT~app");
+    trie.insert("fruit~aPpLe");
+    trie.insert("fruit~banana");
+    trie.insert("FRUIT~apricot");
+
+    // Test case-insensitive prefix search with Delimiter
+    let result: Vec<String> = trie.get_terms_with_prefix("fruit~Ap", true);
+    let expected_result = vec!["fruit~apple", "fruit~aPpLe"];
+
+    assert_contains_same_elements(result, expected_result);
+  }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!
-->

## What does this PR do?
- This PR introduces a Trie data structure within the segment.
- Added support for prefix queries.

## How does this PR work? (optional)
- The Trie seamlessly integrates into the segment, providing efficient insertion, containment check, and prefix search capabilities, including handling case-insensitive cases.
- Support for the prefix phrase query was included.

## Refer to a related PR or issue link
- N.A.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
