### PR TITLE
Write ahead log implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ plugins/.gradle
 # the index created by coredb and server test if default config is used
 data
 server/data
+wal
+server/wal
 
 # the documentation artifacts
 docs/.rustc_info.json

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,18 @@ clean-os-plugin:
 clean:
 	cargo clean
 	rm -rf docs/release
+
+	# index and wal directories created by 'make run'
 	rm -rf data/
+	rm -rf wal/
+
+	# index and wal directories created by 'make rust-apache-logs'
+	rm -fr examples/rust-apache-logs/data/
+	rm -fr examples/rust-apache-logs/wal/
+
+	# index and wal directories created by server integration tests
+	rm -fr server/data/
+	rm -fr server/wal/
 
 clean-all: clean clean-os-plugin
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -24,6 +24,10 @@ uncommitted_segments_threshold = 10
 # Number of days to retain older older logs and metrics.
 retention_days = 30
 
+# Settings for write ahead log.
+write_ahead_log_dir_path = "wal"
+
+
 [server]
 port = 3000
 host = "0.0.0.0"

--- a/config/default.toml
+++ b/config/default.toml
@@ -25,7 +25,7 @@ uncommitted_segments_threshold = 10
 retention_days = 30
 
 # Settings for write ahead log.
-write_ahead_log_dir_path = "wal"
+wal_dir_path = "wal"
 
 
 [server]

--- a/coredb/src/index_manager/index.rs
+++ b/coredb/src/index_manager/index.rs
@@ -380,7 +380,9 @@ impl Index {
       (current_segment_number, current_segment) = self.get_current_segment_ref();
 
       // Append the log message to the current segment.
-      current_segment.append_log_message(time, fields, message)?;
+      current_segment
+        .append_log_message(time, fields, message)
+        .await?;
     }
 
     // Update start and end time of the summary of the current segment.

--- a/coredb/src/index_manager/index.rs
+++ b/coredb/src/index_manager/index.rs
@@ -133,10 +133,8 @@ impl Index {
 
     // WAL storage is always local - we do not store WAL in the cloud.
     let wal_storage = Storage::new(&StorageType::Local).await?;
-    println!("#### Checking if wal dir creation is needed");
     if !wal_storage.check_path_exists(wal_dir_path).await {
       // WAL directory does not exist - create it.
-      println!("#### Creating dir {}", wal_dir_path);
       wal_storage.create_dir(wal_dir_path)?;
     }
 
@@ -216,12 +214,10 @@ impl Index {
 
   /// Insert a new segment in the memory segments map and in the all_segments_summaries map.
   fn insert_new_segment(&self, segment_number: u32, segment: Segment) {
-    println!("#### Inserting in seg summaries");
     self.all_segments_summaries.insert(
       segment_number,
       SegmentSummary::new(segment_number, &segment),
     );
-    println!("#### Inserting in memory seg map");
     self.memory_segments_map.insert(segment_number, segment);
   }
 
@@ -367,24 +363,17 @@ impl Index {
       new_segment.get_id()
     );
 
-    println!("#### now inserting new segment in mem map and summary");
     // Insert new segment in memory_segments_map and all_segments_summaries.
     self.insert_new_segment(new_segment_number, new_segment);
 
-    println!("#### inserting in mem map and summary complete");
-
-    println!("#### now setting current seg number");
     // Appends will start going to the new segment after this point.
     self.metadata.set_current_segment_number(new_segment_number);
 
-    println!("#### now adding to uncommitted seg numbers");
     // Add the original segment number to the uncommitted segment numbers, so that it will be committed
     // by the commit thread.
     self
       .uncommitted_segment_numbers
       .insert(current_segment_number, current_segment_end_time);
-
-    println!("#### returning from check_and_create_new_seg");
   }
 
   /// Append a log message to the current segment of the index.

--- a/coredb/src/index_manager/index.rs
+++ b/coredb/src/index_manager/index.rs
@@ -371,6 +371,8 @@ impl Index {
     // Insert new segment in memory_segments_map and all_segments_summaries.
     self.insert_new_segment(new_segment_number, new_segment);
 
+    println!("#### inserting in mem map and summary complete");
+
     println!("#### now setting current seg number");
     // Appends will start going to the new segment after this point.
     self.metadata.set_current_segment_number(new_segment_number);
@@ -414,9 +416,9 @@ impl Index {
       (current_segment_number, current_segment) = self.get_current_segment_ref();
 
       // Append the log message to the current segment.
-      current_segment
-        .append_log_message(time, fields, message)
-        .await?;
+      current_segment.append_log_message(time, fields, message)?;
+
+      drop(current_segment);
     }
 
     // Update start and end time of the summary of the current segment.

--- a/coredb/src/index_manager/index.rs
+++ b/coredb/src/index_manager/index.rs
@@ -61,6 +61,9 @@ pub struct Index {
   /// Directory where the index is serialized.
   index_dir_path: String,
 
+  /// Directory where the WAL is stored.
+  wal_dir_path: String,
+
   /// Mutex for locking new segment creation - so that only one thread creates a new segment at a time.
   /// Use TokioMutex, as it needs to be held across await points.
   create_new_segment_lock: Arc<TokioMutex<thread::ThreadId>>,
@@ -87,10 +90,15 @@ impl Index {
   /// the function will refresh the existing index instead of creating a new one.
   /// If the refresh process fails, an error will be thrown to indicate the issue.
   #[cfg(test)]
-  pub async fn new(storage_type: &StorageType, index_dir_path: &str) -> Result<Self, CoreDBError> {
+  pub async fn new(
+    storage_type: &StorageType,
+    index_dir_path: &str,
+    wal_dir_path: &str,
+  ) -> Result<Self, CoreDBError> {
     Index::new_with_threshold_params(
       storage_type,
       index_dir_path,
+      wal_dir_path,
       DEFAULT_SEARCH_MEMORY_BUDGET_BYTES,
       DEFAULT_LOG_MESSAGES_THRESHOLD,
       DEFAULT_METRIC_POINTS_THRESHOLD,
@@ -105,7 +113,8 @@ impl Index {
   /// process fails, an error will be thrown to indicate the issue.
   pub async fn new_with_threshold_params(
     storage_type: &StorageType,
-    index_dir: &str,
+    index_dir_path: &str,
+    wal_dir_path: &str,
     search_memory_budget_bytes: u64,
     log_messages_threshold: u32,
     metric_points_threshold: u32,
@@ -113,21 +122,34 @@ impl Index {
   ) -> Result<Self, CoreDBError> {
     info!(
       "Creating index - storage type {:?}, dir {}",
-      storage_type, index_dir
+      storage_type, index_dir_path
     );
 
     let storage = Storage::new(storage_type).await?;
-
-    if !storage.check_path_exists(index_dir).await {
+    if !storage.check_path_exists(index_dir_path).await {
       // Index directory does not exist - create it.
-      storage.create_dir(index_dir)?;
+      storage.create_dir(index_dir_path)?;
+    }
+
+    // WAL storage is always local - we do not store WAL in the cloud.
+    let wal_storage = Storage::new(&StorageType::Local).await?;
+    if !wal_storage.check_path_exists(wal_dir_path).await {
+      // WAL directory does not exist - create it.
+      storage.create_dir(wal_dir_path)?;
     }
 
     // Check whether index directory already has a metadata file.
-    let metadata_path = &format!("{}/{}", index_dir, METADATA_FILE_NAME);
+    let metadata_path = &format!("{}/{}", index_dir_path, METADATA_FILE_NAME);
     if storage.check_path_exists(metadata_path).await {
       // index_dir_path has metadata file, refresh the index instead of creating new one
-      match Self::refresh(storage_type, index_dir, search_memory_budget_bytes).await {
+      match Self::refresh(
+        storage_type,
+        index_dir_path,
+        wal_dir_path,
+        search_memory_budget_bytes,
+      )
+      .await
+      {
         Ok(mut index) => {
           index.search_memory_budget_bytes = search_memory_budget_bytes;
           return Ok(index);
@@ -174,7 +196,8 @@ impl Index {
       metadata,
       all_segments_summaries,
       memory_segments_map,
-      index_dir_path: index_dir.to_owned(),
+      index_dir_path: index_dir_path.to_owned(),
+      wal_dir_path: wal_dir_path.to_owned(),
       commit_refresh_lock,
       create_new_segment_lock,
       search_memory_budget_bytes,
@@ -696,6 +719,7 @@ impl Index {
   pub async fn refresh(
     storage_type: &StorageType,
     index_dir_path: &str,
+    wal_dir_path: &str,
     search_memory_budget_bytes: u64,
   ) -> Result<Self, CoreDBError> {
     info!("Refreshing index from index_dir_path: {}", index_dir_path);
@@ -718,6 +742,7 @@ impl Index {
       all_segments_summaries: DashMap::new(),
       memory_segments_map: DashMap::new(),
       index_dir_path: index_dir_path.to_owned(),
+      wal_dir_path: wal_dir_path.to_owned(),
       commit_refresh_lock,
       create_new_segment_lock,
       search_memory_budget_bytes,
@@ -838,13 +863,20 @@ mod tests {
   use crate::utils::sync::is_sync_send;
 
   // Helper function to create index
-  async fn create_index<'a>(name: &'a str, storage_type: &'a StorageType) -> (Index, String) {
+  async fn create_index<'a>(
+    name: &'a str,
+    storage_type: &'a StorageType,
+  ) -> (Index, String, String) {
     config_test_logger();
 
     let index_dir = TempDir::new("index_test").unwrap();
     let index_dir_path = format!("{}/{}", index_dir.path().to_str().unwrap(), name);
-    let index = Index::new(storage_type, &index_dir_path).await.unwrap();
-    (index, index_dir_path)
+    let wal_dir = TempDir::new("wal_test").unwrap();
+    let wal_dir_path = format!("{}/{}", wal_dir.path().to_str().unwrap(), name);
+    let index = Index::new(storage_type, &index_dir_path, &wal_dir_path)
+      .await
+      .unwrap();
+    (index, index_dir_path, wal_dir_path)
   }
 
   async fn create_index_with_thresholds<'a>(
@@ -854,14 +886,17 @@ mod tests {
     log_messages_threshold: u32,
     metric_points_threshold: u32,
     uncommitted_segments_threshold: u32,
-  ) -> (Index, String) {
+  ) -> (Index, String, String) {
     config_test_logger();
 
     let index_dir = TempDir::new("index_test").unwrap();
     let index_dir_path = format!("{}/{}", index_dir.path().to_str().unwrap(), name);
+    let wal_dir = TempDir::new("wal_test").unwrap();
+    let wal_dir_path = format!("{}/{}", wal_dir.path().to_str().unwrap(), name);
     let index = Index::new_with_threshold_params(
       storage_type,
       &index_dir_path,
+      &wal_dir_path,
       memory_budget,
       log_messages_threshold,
       metric_points_threshold,
@@ -869,7 +904,7 @@ mod tests {
     )
     .await
     .unwrap();
-    (index, index_dir_path)
+    (index, index_dir_path, wal_dir_path)
   }
 
   #[tokio::test]
@@ -882,8 +917,14 @@ mod tests {
       index_dir.path().to_str().unwrap(),
       "test_empty_index"
     );
+    let wal_dir = TempDir::new("wal_test").unwrap();
+    let wal_dir_path = format!(
+      "{}/{}",
+      wal_dir.path().to_str().unwrap(),
+      "test_empty_index"
+    );
 
-    let index = Index::new(&StorageType::Local, &index_dir_path)
+    let index = Index::new(&StorageType::Local, &index_dir_path, &wal_dir_path)
       .await
       .unwrap();
     let (_, segment_ref) = index.get_current_segment_ref();
@@ -914,7 +955,8 @@ mod tests {
   #[tokio::test]
   async fn test_commit_refresh() {
     let storage_type = StorageType::Local;
-    let (expected, index_dir_path) = create_index("test_commit_refresh", &storage_type).await;
+    let (expected, index_dir_path, wal_dir_path) =
+      create_index("test_commit_refresh", &storage_type).await;
     let num_log_messages = 5;
     let message_prefix = "content#";
     let num_metric_points = 5;
@@ -949,7 +991,7 @@ mod tests {
     }
 
     expected.commit(true).await.expect("Could not commit");
-    let received = Index::refresh(&storage_type, &index_dir_path, 1024)
+    let received = Index::refresh(&storage_type, &index_dir_path, &wal_dir_path, 1024)
       .await
       .unwrap();
 
@@ -976,7 +1018,8 @@ mod tests {
   #[tokio::test]
   async fn test_basic_search_logs() {
     let storage_type = StorageType::Local;
-    let (index, _index_dir_path) = create_index("test_basic_search", &storage_type).await;
+    let (index, _index_dir_path, _wal_dir_path) =
+      create_index("test_basic_search", &storage_type).await;
     let num_log_messages = 1000;
     let message_prefix = "this is my log message";
     let mut expected_log_messages: Vec<String> = Vec::new();
@@ -1074,7 +1117,8 @@ mod tests {
   #[tokio::test]
   async fn test_basic_time_series() {
     let storage_type = StorageType::Local;
-    let (index, _index_dir_path) = create_index("test_basic_time_series", &storage_type).await;
+    let (index, _index_dir_path, _wal_dir_path) =
+      create_index("test_basic_time_series", &storage_type).await;
     let num_metric_points = 1000;
     let mut expected_metric_points: Vec<MetricPoint> = Vec::new();
 
@@ -1113,7 +1157,7 @@ mod tests {
     for _ in 0..10 {
       let storage_type = StorageType::Local;
       let storage = Storage::new(&storage_type).await?;
-      let (index, index_dir_path) = create_index_with_thresholds(
+      let (index, index_dir_path, wal_dir_path) = create_index_with_thresholds(
         "test_two_segments",
         &storage_type,
         1024 * 1024,
@@ -1160,7 +1204,7 @@ mod tests {
       index.commit(true).await.expect("Could not commit index");
 
       // Read the index from disk and see that it has expected number of log messages and metric points.
-      let index = Index::refresh(&storage_type, &index_dir_path, 1024 * 1024)
+      let index = Index::refresh(&storage_type, &index_dir_path, &wal_dir_path, 1024 * 1024)
         .await
         .expect("Could not refresh index");
       let original_segment = Segment::refresh(&storage, &original_segment_path)
@@ -1215,7 +1259,7 @@ mod tests {
 
       // Force a commit and refresh. The index should still have only 2 segments.
       index.commit(true).await.expect("Could not commit index");
-      let index = Index::refresh(&storage_type, &index_dir_path, 1024 * 1024)
+      let index = Index::refresh(&storage_type, &index_dir_path, &wal_dir_path, 1024 * 1024)
         .await
         .unwrap();
       let mut original_segment = Segment::refresh(&storage, &original_segment_path)
@@ -1278,7 +1322,7 @@ mod tests {
 
       // Force a commit and refresh.
       index.commit(true).await.expect("Could not commit index");
-      let index = Index::refresh(&storage_type, &index_dir_path, 1024 * 1024)
+      let index = Index::refresh(&storage_type, &index_dir_path, &wal_dir_path, 1024 * 1024)
         .await
         .expect("Could not refresh index");
       original_segment = Segment::refresh(&storage, &original_segment_path)
@@ -1318,15 +1362,15 @@ mod tests {
 
       // Commit and refresh a few times. The index should not change.
       index.commit(true).await.expect("Could not commit index");
-      let index = Index::refresh(&storage_type, &index_dir_path, 1024 * 1024)
+      let index = Index::refresh(&storage_type, &index_dir_path, &wal_dir_path, 1024 * 1024)
         .await
         .expect("Could not refresh index");
       index.commit(true).await.expect("Could not commit index");
       index.commit(true).await.expect("Could not commit index");
-      Index::refresh(&storage_type, &index_dir_path, 1024 * 1024)
+      Index::refresh(&storage_type, &index_dir_path, &wal_dir_path, 1024 * 1024)
         .await
         .unwrap();
-      let index_final = Index::refresh(&storage_type, &index_dir_path, 1024 * 1024)
+      let index_final = Index::refresh(&storage_type, &index_dir_path, &wal_dir_path, 1024 * 1024)
         .await
         .unwrap();
       let (_, index_final_current_segment_ref) = index_final.get_current_segment_ref();
@@ -1357,7 +1401,7 @@ mod tests {
     let commit_after = 1000;
 
     // Create a new index with a low threshold for the segment size.
-    let (mut index, index_dir_path) = create_index_with_thresholds(
+    let (mut index, index_dir_path, wal_dir_path) = create_index_with_thresholds(
       "test_multiple_segments_logs",
       &storage_type,
       1024 * 1024,
@@ -1399,7 +1443,7 @@ mod tests {
     let end_time = Utc::now().timestamp_millis() as u64;
 
     // Read the index from disk.
-    index = match Index::refresh(&storage_type, &index_dir_path, 1024 * 1024).await {
+    index = match Index::refresh(&storage_type, &index_dir_path, &wal_dir_path, 1024 * 1024).await {
       Ok(index) => index,
       Err(err) => {
         error!("Error refreshing index: {:?}", err);
@@ -1472,7 +1516,7 @@ mod tests {
   #[tokio::test]
   async fn test_search_logs_count() {
     let storage_type = StorageType::Local;
-    let (index, _index_dir_path) = create_index_with_thresholds(
+    let (index, _index_dir_path, _wal_dir_path) = create_index_with_thresholds(
       "test_search_logs_count",
       &storage_type,
       1024 * 1024,
@@ -1523,7 +1567,7 @@ mod tests {
   #[tokio::test]
   async fn test_multiple_segments_metric_points() {
     let storage_type = StorageType::Local;
-    let (mut index, index_dir_path) = create_index_with_thresholds(
+    let (mut index, index_dir_path, wal_dir_path) = create_index_with_thresholds(
       "test_multiple_segments_metric_points",
       &storage_type,
       1024 * 1024,
@@ -1559,7 +1603,7 @@ mod tests {
     sleep(Duration::from_millis(10000));
 
     // Refresh the segment from disk.
-    index = Index::refresh(&storage_type, &index_dir_path, 1024 * 1024)
+    index = Index::refresh(&storage_type, &index_dir_path, &wal_dir_path, 1024 * 1024)
       .await
       .unwrap();
     let (_, current_segment_ref) = index.get_current_segment_ref();
@@ -1598,9 +1642,9 @@ mod tests {
     let storage_type = StorageType::Local;
 
     // Create a path within index_dir that does not exist.
-    let temp_path_buf = index_dir.path().join("doesnotexist");
+    let temp_path_buf = index_dir.path().join("doesnotexist_index");
 
-    let index = Index::new(&storage_type, temp_path_buf.to_str().unwrap())
+    let index = Index::new(&storage_type, temp_path_buf.to_str().unwrap(), "/tmp")
       .await
       .unwrap();
 
@@ -1618,22 +1662,34 @@ mod tests {
       .expect("Could not create storage");
 
     // Expect an error when directory isn't present.
-    let mut result =
-      Index::refresh(&storage_type, temp_path_buf.to_str().unwrap(), 1024 * 1024).await;
+    let mut result = Index::refresh(
+      &storage_type,
+      temp_path_buf.to_str().unwrap(),
+      "/tmp",
+      1024 * 1024,
+    )
+    .await;
     assert!(result.is_err());
 
     // Expect an error when metadata file is not present in the directory.
     storage
       .create_dir(temp_path_buf.to_str().expect("Could not create dir path"))
       .expect("Could not create dir");
-    result = Index::refresh(&storage_type, temp_path_buf.to_str().unwrap(), 1024 * 1024).await;
+    result = Index::refresh(
+      &storage_type,
+      temp_path_buf.to_str().unwrap(),
+      "/tmp",
+      1024 * 1024,
+    )
+    .await;
     assert!(result.is_err());
   }
 
   #[tokio::test]
   async fn test_overlap_one_segment() {
     let storage_type = StorageType::Local;
-    let (index, _index_dir_path) = create_index("test_overlap_one_segment", &storage_type).await;
+    let (index, _index_dir_path, _wal_dir_path) =
+      create_index("test_overlap_one_segment", &storage_type).await;
 
     index
       .append_log_message(1000, &HashMap::new(), "message_1")
@@ -1659,13 +1715,26 @@ mod tests {
       index_dir.path().to_str().unwrap(),
       "test_overlap_multiple_segments"
     );
+    let wal_dir = TempDir::new("wal_test").unwrap();
+    let wal_dir_path = format!(
+      "{}/{}",
+      wal_dir.path().to_str().unwrap(),
+      "test_overlap_multiple_segments"
+    );
     let storage_type = StorageType::Local;
 
     // The log_messages_threshold is set to 2, so that a new segment gets created after every 2 messages.
-    let index =
-      Index::new_with_threshold_params(&storage_type, &index_dir_path, 1024 * 1024, 2, 100, 10)
-        .await
-        .unwrap();
+    let index = Index::new_with_threshold_params(
+      &storage_type,
+      &index_dir_path,
+      &wal_dir_path,
+      1024 * 1024,
+      2,
+      100,
+      10,
+    )
+    .await
+    .unwrap();
 
     // Setting it high to test out that there is no single-threaded deadlock while commiting.
     // Note that if you change this value, some of the assertions towards the end of this test
@@ -1721,7 +1790,7 @@ mod tests {
 
     // Create a new index with a low threshold for the segment size.
     let name = &format!("test_concurrent_append_{}", num_segments_in_memory);
-    let (index, index_dir_path) = create_index_with_thresholds(
+    let (index, index_dir_path, wal_dir_path) = create_index_with_thresholds(
       name,
       &storage_type,
       search_memory_budget_bytes,
@@ -1785,7 +1854,7 @@ mod tests {
       .await
       .expect("Could not commit index");
 
-    let index = Index::refresh(&storage_type, &index_dir_path, 1024 * 1024)
+    let index = Index::refresh(&storage_type, &index_dir_path, &wal_dir_path, 1024 * 1024)
       .await
       .expect("Could not refresh index");
     let expected_len = num_threads * num_appends_per_thread;
@@ -1824,7 +1893,7 @@ mod tests {
   #[tokio::test]
   async fn test_reusing_index_when_available() {
     let storage_type = StorageType::Local;
-    let (index, index_dir_path) = create_index_with_thresholds(
+    let (index, index_dir_path, wal_dir_path) = create_index_with_thresholds(
       "test_reusing_index_when_available",
       &storage_type,
       1024 * 1024,
@@ -1843,10 +1912,17 @@ mod tests {
     index.commit(true).await.expect("Could not commit index");
 
     // Create one more new index using same dir location
-    let index =
-      Index::new_with_threshold_params(&storage_type, &index_dir_path, 1024 * 1024, 10, 100, 10)
-        .await
-        .unwrap();
+    let index = Index::new_with_threshold_params(
+      &storage_type,
+      &index_dir_path,
+      &wal_dir_path,
+      1024 * 1024,
+      10,
+      100,
+      10,
+    )
+    .await
+    .unwrap();
 
     let query_message = r#"{
         "query": {
@@ -1879,11 +1955,20 @@ mod tests {
     // Create a new index in an empty directory - this should work.
     let index_dir = TempDir::new("index_test").unwrap();
     let index_dir_path = index_dir.path().to_str().unwrap();
+    let wal_dir = TempDir::new("wal_test").unwrap();
+    let wal_dir_path = wal_dir.path().to_str().unwrap();
     let storage_type = StorageType::Local;
 
-    let index =
-      Index::new_with_threshold_params(&storage_type, index_dir_path, 1024 * 1024, 10, 100, 10)
-        .await;
+    let index = Index::new_with_threshold_params(
+      &storage_type,
+      index_dir_path,
+      wal_dir_path,
+      1024 * 1024,
+      10,
+      100,
+      10,
+    )
+    .await;
     assert!(index.is_ok());
   }
 
@@ -1897,7 +1982,7 @@ mod tests {
     let storage_type = StorageType::Local;
     let some_segment_size_bytes = (0.0003 * 1024.0 * 1024.0) as u64;
     let search_memory_budget_bytes = num_segments_in_memory * some_segment_size_bytes;
-    let (index, _index_dir_path) = create_index_with_thresholds(
+    let (index, _index_dir_path, _wal_dir_path) = create_index_with_thresholds(
       "test_limited_memory",
       &storage_type,
       search_memory_budget_bytes,
@@ -1974,7 +2059,7 @@ mod tests {
   #[tokio::test]
   async fn test_delete_segment_in_memory() {
     let storage_type = StorageType::Local;
-    let (index, _index_dir_path) =
+    let (index, _index_dir_path, _wal_dir_path) =
       create_index("test_delete_segment_in_memory", &storage_type).await;
     let message = "test_message";
     index
@@ -2003,7 +2088,7 @@ mod tests {
     let segment_size_approx_bytes = (0.0003 * 1024.0 * 1024.0) as u64;
     let search_memory_budget_bytes = num_segments_in_memory * segment_size_approx_bytes;
     let storage_type = StorageType::Local;
-    let (index, _index_dir_path) = create_index_with_thresholds(
+    let (index, _index_dir_path, _wal_dir_path) = create_index_with_thresholds(
       "test_delete_multiple_segments",
       &storage_type,
       search_memory_budget_bytes,
@@ -2058,7 +2143,7 @@ mod tests {
     let storage_type = StorageType::Local;
     let log_messages_threshold = 1000;
     let uncommitted_segments_threshold = 10;
-    let (index, _index_dir_path) = create_index_with_thresholds(
+    let (index, _index_dir_path, _wal_dir_path) = create_index_with_thresholds(
       "test_uncommitted_segments",
       &storage_type,
       5 * 1024 * 1024,

--- a/coredb/src/index_manager/index.rs
+++ b/coredb/src/index_manager/index.rs
@@ -216,10 +216,12 @@ impl Index {
 
   /// Insert a new segment in the memory segments map and in the all_segments_summaries map.
   fn insert_new_segment(&self, segment_number: u32, segment: Segment) {
+    println!("#### Inserting in seg summaries");
     self.all_segments_summaries.insert(
       segment_number,
       SegmentSummary::new(segment_number, &segment),
     );
+    println!("#### Inserting in memory seg map");
     self.memory_segments_map.insert(segment_number, segment);
   }
 
@@ -365,17 +367,22 @@ impl Index {
       new_segment.get_id()
     );
 
+    println!("#### now inserting new segment in mem map and summary");
     // Insert new segment in memory_segments_map and all_segments_summaries.
     self.insert_new_segment(new_segment_number, new_segment);
 
+    println!("#### now setting current seg number");
     // Appends will start going to the new segment after this point.
     self.metadata.set_current_segment_number(new_segment_number);
 
+    println!("#### now adding to uncommitted seg numbers");
     // Add the original segment number to the uncommitted segment numbers, so that it will be committed
     // by the commit thread.
     self
       .uncommitted_segment_numbers
       .insert(current_segment_number, current_segment_end_time);
+
+    println!("#### returning from check_and_create_new_seg");
   }
 
   /// Append a log message to the current segment of the index.

--- a/coredb/src/index_manager/index.rs
+++ b/coredb/src/index_manager/index.rs
@@ -2096,13 +2096,18 @@ mod tests {
         .append_log_message(end, &HashMap::new(), message_end)
         .await
         .expect("Could not append log message");
-      index.commit(true).await.expect("Could not commit index");
+      index.commit(false).await.expect("Could not commit index");
     }
 
     // We'll have num_segments segments, plus one empty segment at the end.
     assert_eq!(index.all_segments_summaries.len() as u64, num_segments + 1);
 
     // We shouldn't have more than specified segments in memory.
+    println!(
+      "##### memory = {}, num segments in memory = {}",
+      index.memory_segments_map.len(),
+      num_segments_in_memory
+    );
     assert!(index.memory_segments_map.len() as u64 <= num_segments_in_memory);
 
     // Check the queries return results as expected.

--- a/coredb/src/index_manager/segment_summary.rs
+++ b/coredb/src/index_manager/segment_summary.rs
@@ -137,8 +137,8 @@ mod tests {
     );
   }
 
-  #[test]
-  pub fn test_sort_segment_summary() {
+  #[tokio::test]
+  pub async fn test_sort_segment_summary() {
     let num_segments = 3;
     let mut segment_summaries = Vec::new();
     let mut expected_segment_ids = Vec::new();
@@ -148,6 +148,7 @@ mod tests {
       let segment = Segment::new();
       segment
         .append_log_message(i, &HashMap::new(), "some log message")
+        .await
         .expect("Could not append to segment");
       let segment_summary = SegmentSummary::new(i as u32, &segment);
       segment_summaries.push(segment_summary);

--- a/coredb/src/index_manager/segment_summary.rs
+++ b/coredb/src/index_manager/segment_summary.rs
@@ -148,7 +148,6 @@ mod tests {
       let segment = Segment::new_with_temp_wal();
       segment
         .append_log_message(i, &HashMap::new(), "some log message")
-        .await
         .expect("Could not append to segment");
       let segment_summary = SegmentSummary::new(i as u32, &segment);
       segment_summaries.push(segment_summary);

--- a/coredb/src/index_manager/segment_summary.rs
+++ b/coredb/src/index_manager/segment_summary.rs
@@ -124,7 +124,7 @@ mod tests {
     // Check if the SegmentSummary implements Sync + Send.
     is_sync_send::<SegmentSummary>();
 
-    let segment = Segment::new();
+    let segment = Segment::new_with_temp_wal();
     let segment_summary = SegmentSummary::new(1, &segment);
 
     assert_eq!(segment_summary.get_segment_id(), segment.get_id());
@@ -145,7 +145,7 @@ mod tests {
 
     // Create a few segments along with their summaries.
     for i in 1..=num_segments {
-      let segment = Segment::new();
+      let segment = Segment::new_with_temp_wal();
       segment
         .append_log_message(i, &HashMap::new(), "some log message")
         .await

--- a/coredb/src/lib.rs
+++ b/coredb/src/lib.rs
@@ -53,6 +53,7 @@ impl CoreDB {
       Ok(settings) => {
         let coredb_settings = settings.get_coredb_settings();
         let index_dir_path = &coredb_settings.get_index_dir_path();
+        let wal_dir_path = &coredb_settings.get_wal_dir_path();
         let default_index_name = coredb_settings.get_default_index_name();
         let search_memory_budget_bytes = coredb_settings.get_search_memory_budget_bytes();
         let append_log_messages_threshold = coredb_settings.get_log_messages_threshold();
@@ -77,9 +78,11 @@ impl CoreDB {
                 index_dir_path
               );
               let default_index_dir_path = format!("{}/{}", index_dir_path, default_index_name);
+              let default_wal_dir_path = format!("{}/{}", wal_dir_path, default_index_name);
               let index = Index::new_with_threshold_params(
                 &storage_type,
                 &default_index_dir_path,
+                &default_wal_dir_path,
                 search_memory_budget_bytes,
                 append_log_messages_threshold,
                 append_metric_points_threshold,
@@ -90,9 +93,11 @@ impl CoreDB {
             } else {
               for index_name in index_names {
                 let full_index_path_name = format!("{}/{}", index_dir_path, index_name);
+                let full_wal_path_name = format!("{}/{}", wal_dir_path, index_name);
                 let index = Index::refresh(
                   &storage_type,
                   &full_index_path_name,
+                  &full_wal_path_name,
                   search_memory_budget_bytes,
                 )
                 .await?;
@@ -106,9 +111,11 @@ impl CoreDB {
               index_dir_path
             );
             let default_index_dir_path = format!("{}/{}", index_dir_path, default_index_name);
+            let default_wal_dir_path = format!("{}/{}", wal_dir_path, default_index_name);
             let index = Index::new_with_threshold_params(
               &storage_type,
               &default_index_dir_path,
+              &default_wal_dir_path,
               search_memory_budget_bytes,
               append_log_messages_threshold,
               append_metric_points_threshold,
@@ -281,8 +288,10 @@ impl CoreDB {
     let settings = Settings::new(config_dir_path).unwrap();
     let coredb_settings = settings.get_coredb_settings();
     let index_dir_path = coredb_settings.get_index_dir_path();
+    let wal_dir_path = coredb_settings.get_wal_dir_path();
     let default_index_name = coredb_settings.get_default_index_name();
     let default_index_dir_path = format!("{}/{}", index_dir_path, default_index_name);
+    let default_wal_dir_path = format!("{}/{}", wal_dir_path, default_index_name);
     let search_memory_budget_bytes = coredb_settings.get_search_memory_budget_bytes();
     let storage_type = coredb_settings.get_storage_type()?;
 
@@ -290,6 +299,7 @@ impl CoreDB {
     let index = Index::refresh(
       &storage_type,
       &default_index_dir_path,
+      &default_wal_dir_path,
       search_memory_budget_bytes,
     )
     .await?;
@@ -326,6 +336,7 @@ impl CoreDB {
   pub async fn create_index(&self, index_name: &str) -> Result<(), CoreDBError> {
     let coredb_settings = self.settings.get_coredb_settings();
     let index_dir_path = coredb_settings.get_index_dir_path();
+    let wal_dir_path = coredb_settings.get_wal_dir_path();
     let search_memory_budget_bytes = coredb_settings.get_search_memory_budget_bytes();
     let append_log_messages_threshold = coredb_settings.get_log_messages_threshold();
     let append_metric_points_threshold = coredb_settings.get_metric_points_threshold();
@@ -333,9 +344,12 @@ impl CoreDB {
     let storage_type = self.settings.get_coredb_settings().get_storage_type()?;
 
     let index_dir_path = format!("{}/{}", index_dir_path, index_name);
+    let wal_dir_path = format!("{}/{}", wal_dir_path, index_name);
+
     let index = Index::new_with_threshold_params(
       &storage_type,
       &index_dir_path,
+      &wal_dir_path,
       search_memory_budget_bytes,
       append_log_messages_threshold,
       append_metric_points_threshold,
@@ -408,7 +422,7 @@ mod tests {
   use super::*;
 
   /// Helper function to create a test configuration.
-  fn create_test_config(config_dir_path: &str, index_dir_path: &str) {
+  fn create_test_config(config_dir_path: &str, index_dir_path: &str, wal_dir_path: &str) {
     // Create a test config in the directory config_dir_path.
     let config_file_path = get_joined_path(
       config_dir_path,
@@ -417,11 +431,13 @@ mod tests {
 
     {
       let index_dir_path_line = format!("index_dir_path = \"{}\"\n", index_dir_path);
+      let wal_dir_path_line = format!("wal_dir_path = \"{}\"\n", wal_dir_path);
       let default_index_name_line = format!("default_index_name = \"{}\"\n", ".default");
 
       let mut file = std::fs::File::create(config_file_path).unwrap();
       file.write_all(b"[coredb]\n").unwrap();
       file.write_all(index_dir_path_line.as_bytes()).unwrap();
+      file.write_all(wal_dir_path_line.as_bytes()).unwrap();
       file.write_all(default_index_name_line.as_bytes()).unwrap();
       file.write_all(b"log_messages_threshold = 1000\n").unwrap();
       file
@@ -444,7 +460,9 @@ mod tests {
     let config_dir_path = config_dir.path().to_str().unwrap();
     let index_dir = TempDir::new("index_test").unwrap();
     let index_dir_path = index_dir.path().to_str().unwrap();
-    create_test_config(config_dir_path, index_dir_path);
+    let wal_dir = TempDir::new("wal_test").unwrap();
+    let wal_dir_path = wal_dir.path().to_str().unwrap();
+    create_test_config(config_dir_path, index_dir_path, wal_dir_path);
     println!("Config dir path {}", config_dir_path);
 
     // Create a new coredb instance.

--- a/coredb/src/lib.rs
+++ b/coredb/src/lib.rs
@@ -407,6 +407,17 @@ impl CoreDB {
 
     Ok(())
   }
+
+  /// Flush write ahead log.
+  pub async fn flush_wal(&self) {
+    // Get the default index.
+    let default_index_name = self.get_default_index_name();
+    let temp_reference = self.index_map.get(default_index_name).unwrap();
+    let index = temp_reference.value();
+
+    // Flush the WAL for the index.
+    index.flush_wal().await;
+  }
 }
 
 #[cfg(test)]

--- a/coredb/src/policy_manager/retention_policy.rs
+++ b/coredb/src/policy_manager/retention_policy.rs
@@ -49,7 +49,7 @@ mod tests {
     // Create three segments: one from 10 days ago, one from 5 days ago and one from 1 day ago
     let retention_days = 7;
     let days_to_secs = |days: u64| days * 24 * 60 * 60_u64;
-    let segment = Segment::new();
+    let segment = Segment::new_with_temp_wal();
     let segment1 = SegmentSummary::new(0, &segment);
     segment1.update_start_end_time_test(
       current_secs - days_to_secs(9),

--- a/coredb/src/request_manager/promql.rs
+++ b/coredb/src/request_manager/promql.rs
@@ -1126,7 +1126,11 @@ mod tests {
     let storage_type = StorageType::Local;
     let index_dir = TempDir::new("index_test").unwrap();
     let index_dir_path = format!("{}/{}", index_dir.path().to_str().unwrap(), name);
-    let index = Index::new(&storage_type, &index_dir_path).await.unwrap();
+    let wal_dir = TempDir::new("wal_test").unwrap();
+    let wal_dir_path = format!("{}/{}", wal_dir.path().to_str().unwrap(), name);
+    let index = Index::new(&storage_type, &index_dir_path, &wal_dir_path)
+      .await
+      .unwrap();
 
     // Append metric points to the index.
     let timestamp = Utc::now().timestamp_millis() as u64;

--- a/coredb/src/request_manager/query_dsl.rs
+++ b/coredb/src/request_manager/query_dsl.rs
@@ -545,7 +545,7 @@ mod tests {
   use super::*;
   use pest::Parser;
 
-  fn create_mock_segment() -> Segment {
+  async fn create_mock_segment() -> Segment {
     config_test_logger();
 
     let segment = Segment::new();
@@ -563,6 +563,7 @@ mod tests {
       fields.insert("key".to_string(), key.to_string());
       segment
         .append_log_message(Utc::now().timestamp_millis() as u64, &fields, message)
+        .await
         .unwrap();
     }
 
@@ -571,7 +572,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_search_with_must_query() {
-    let segment = create_mock_segment();
+    let segment = create_mock_segment().await;
 
     let query_dsl_query = r#"{
       "query": {
@@ -611,7 +612,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_search_with_should_query() {
-    let segment = create_mock_segment();
+    let segment = create_mock_segment().await;
 
     let query_dsl_query = r#"{
       "query": {
@@ -652,7 +653,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_search_with_must_not_query() {
-    let segment = create_mock_segment();
+    let segment = create_mock_segment().await;
 
     let query_dsl_query = r#"{
       "query": {
@@ -685,7 +686,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_search_with_boolean_query() {
-    let segment = create_mock_segment();
+    let segment = create_mock_segment().await;
 
     let query_dsl_query = r#"{
         "query": {
@@ -730,7 +731,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_search_with_match_query() {
-    let segment = create_mock_segment();
+    let segment = create_mock_segment().await;
 
     let query_dsl_query = r#"{
       "query": {
@@ -768,7 +769,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_search_with_match_phrase_query() {
-    let segment = create_mock_segment();
+    let segment = create_mock_segment().await;
 
     let query_dsl_query = r#"{
       "query": {
@@ -810,7 +811,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_search_with_match_all_query_with_multiple_terms_anded() {
-    let segment = create_mock_segment();
+    let segment = create_mock_segment().await;
 
     let query_dsl_query = r#"{
         "query": {
@@ -852,7 +853,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_search_with_match_all_query_with_multiple_terms() {
-    let segment = create_mock_segment();
+    let segment = create_mock_segment().await;
 
     let query_dsl_query = r#"{
       "query": {
@@ -893,7 +894,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_search_with_match_all_query() {
-    let segment = create_mock_segment();
+    let segment = create_mock_segment().await;
 
     let query_dsl_query = r#"{
       "query": {
@@ -926,7 +927,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_search_with_term_query() {
-    let segment = create_mock_segment();
+    let segment = create_mock_segment().await;
 
     let query_dsl_query = r#"{
       "query": {
@@ -959,7 +960,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_search_with_terms_array_query() {
-    let segment = create_mock_segment();
+    let segment = create_mock_segment().await;
 
     let query_dsl_query = r#"{
       "query": {
@@ -994,7 +995,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_search_with_nested_boolean_query() {
-    let segment = create_mock_segment();
+    let segment = create_mock_segment().await;
 
     let query_dsl_query = r#"{
         "query": {

--- a/coredb/src/request_manager/query_dsl.rs
+++ b/coredb/src/request_manager/query_dsl.rs
@@ -563,7 +563,6 @@ mod tests {
       fields.insert("key".to_string(), key.to_string());
       segment
         .append_log_message(Utc::now().timestamp_millis() as u64, &fields, message)
-        .await
         .unwrap();
     }
 

--- a/coredb/src/request_manager/query_dsl.rs
+++ b/coredb/src/request_manager/query_dsl.rs
@@ -548,7 +548,7 @@ mod tests {
   async fn create_mock_segment() -> Segment {
     config_test_logger();
 
-    let segment = Segment::new();
+    let segment = Segment::new_with_temp_wal();
 
     let log_messages = [
       ("log 1", "this is a test log message"),

--- a/coredb/src/segment_manager/mod.rs
+++ b/coredb/src/segment_manager/mod.rs
@@ -9,3 +9,4 @@ mod metadata;
 pub mod search_logs;
 pub(crate) mod search_metrics;
 pub(super) mod segment;
+pub mod wal;

--- a/coredb/src/segment_manager/search_logs.rs
+++ b/coredb/src/segment_manager/search_logs.rs
@@ -1390,7 +1390,7 @@ mod tests {
   fn create_mock_segment() -> Segment {
     config_test_logger();
 
-    let segment = Segment::new();
+    let segment = Segment::new_with_temp_wal();
 
     segment.insert_in_terms("term1", 1);
     segment.insert_in_terms("term2", 2);
@@ -1456,7 +1456,7 @@ mod tests {
 
   #[test]
   fn test_get_postings_lists_empty_segment() {
-    let segment = Segment::new();
+    let segment = Segment::new_with_temp_wal();
     let terms = vec!["term1".to_string(), "term2".to_string()];
     let result = segment.get_postings_lists(&terms);
     assert!(matches!(result, Err(QueryError::PostingsListError(_))));
@@ -1747,7 +1747,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_match_exact_phrase() {
-    let segment = Segment::new();
+    let segment = Segment::new_with_temp_wal();
 
     segment
       .append_log_message(1001, &HashMap::new(), "log 1")

--- a/coredb/src/segment_manager/search_logs.rs
+++ b/coredb/src/segment_manager/search_logs.rs
@@ -1745,18 +1745,21 @@ mod tests {
     );
   }
 
-  #[test]
-  fn test_match_exact_phrase() {
+  #[tokio::test]
+  async fn test_match_exact_phrase() {
     let segment = Segment::new();
 
     segment
       .append_log_message(1001, &HashMap::new(), "log 1")
+      .await
       .unwrap();
     segment
       .append_log_message(1002, &HashMap::new(), "log 2")
+      .await
       .unwrap();
     segment
       .append_log_message(1003, &HashMap::new(), "log 3")
+      .await
       .unwrap();
 
     // Get all log message IDs from the forward map.
@@ -1775,6 +1778,7 @@ mod tests {
     fields.insert("field_name".to_string(), "log 3".to_string());
     segment
       .append_log_message(1004, &fields, "some message")
+      .await
       .unwrap();
 
     let all_log_ids_with_fields: Vec<u32> = segment

--- a/coredb/src/segment_manager/search_logs.rs
+++ b/coredb/src/segment_manager/search_logs.rs
@@ -1751,15 +1751,12 @@ mod tests {
 
     segment
       .append_log_message(1001, &HashMap::new(), "log 1")
-      .await
       .unwrap();
     segment
       .append_log_message(1002, &HashMap::new(), "log 2")
-      .await
       .unwrap();
     segment
       .append_log_message(1003, &HashMap::new(), "log 3")
-      .await
       .unwrap();
 
     // Get all log message IDs from the forward map.
@@ -1778,7 +1775,6 @@ mod tests {
     fields.insert("field_name".to_string(), "log 3".to_string());
     segment
       .append_log_message(1004, &fields, "some message")
-      .await
       .unwrap();
 
     let all_log_ids_with_fields: Vec<u32> = segment

--- a/coredb/src/segment_manager/search_metrics.rs
+++ b/coredb/src/segment_manager/search_metrics.rs
@@ -148,7 +148,7 @@ mod tests {
   fn create_segment() -> Segment {
     config_test_logger();
 
-    let segment = Segment::new();
+    let segment = Segment::new_with_temp_wal();
 
     // Create a couple of metric points.
     let mut label_set_1 = HashMap::new();

--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -77,18 +77,6 @@ impl Segment {
     }
   }
 
-  pub fn remove_wal(&self) -> Result<(), CoreDBError> {
-    let wal_clone = self.wal.clone();
-    let wal = &mut wal_clone.lock();
-    wal.remove()
-  }
-
-  #[cfg(test)]
-  pub fn new_with_temp_wal() -> Self {
-    let wal_file_path = format!("/tmp/{}.tmp", uuid::Uuid::new_v4());
-    Self::new(&wal_file_path)
-  }
-
   /// Get the terms in this segment.
   pub fn get_terms(&self) -> &DashMap<String, u32> {
     &self.terms
@@ -429,6 +417,28 @@ impl Segment {
   #[cfg(test)]
   pub fn get_metadata_file_name() -> String {
     METADATA_FILE_NAME.to_owned()
+  }
+
+  /// Remove the write ahead log - typically called when after a segment is committed and will
+  /// no longer be written to.
+  pub fn remove_wal(&self) -> Result<(), CoreDBError> {
+    let wal_clone = self.wal.clone();
+    let wal = &mut wal_clone.lock();
+    wal.remove()
+  }
+
+  /// Flush write ahead log to disk.
+  pub fn flush_wal(&self) -> Result<(), CoreDBError> {
+    let wal_clone = self.wal.clone();
+    let wal = &mut wal_clone.lock();
+    wal.flush()
+  }
+
+  #[cfg(test)]
+  /// Create a new segment with a temporary WAL file.
+  pub fn new_with_temp_wal() -> Self {
+    let wal_file_path = format!("/tmp/{}.tmp", uuid::Uuid::new_v4());
+    Self::new(&wal_file_path)
   }
 }
 

--- a/coredb/src/segment_manager/segment.rs
+++ b/coredb/src/segment_manager/segment.rs
@@ -77,6 +77,12 @@ impl Segment {
     }
   }
 
+  pub fn remove_wal(&self) -> Result<(), CoreDBError> {
+    let wal_clone = self.wal.clone();
+    let wal = &mut wal_clone.lock();
+    wal.remove()
+  }
+
   #[cfg(test)]
   pub fn new_with_temp_wal() -> Self {
     let wal_file_path = format!("/tmp/{}.tmp", uuid::Uuid::new_v4());

--- a/coredb/src/segment_manager/wal.rs
+++ b/coredb/src/segment_manager/wal.rs
@@ -25,11 +25,16 @@ impl WriteAheadLog {
   }
 
   pub async fn append(&self, entry: Value) -> Result<(), CoreDBError> {
-    let mut buffer = self.buffer.lock().await;
-    buffer.push(entry);
+    let num_entries;
 
-    if buffer.len() >= MAX_ENTRIES {
-      drop(buffer); // Release the lock before flushing
+    {
+      // Write in a new scope to release buffer lock immediately.
+      let mut buffer = self.buffer.lock().await;
+      buffer.push(entry);
+      num_entries = buffer.len();
+    }
+
+    if num_entries >= MAX_ENTRIES {
       self.flush().await?;
     }
     Ok(())
@@ -61,6 +66,7 @@ mod tests {
   use std::fs;
   use std::path::Path;
   use tempfile::NamedTempFile;
+  use tokio::task;
 
   #[tokio::test]
   async fn test_write_and_flush() {
@@ -96,5 +102,58 @@ mod tests {
     assert_eq!(contents.matches('\n').count(), MAX_ENTRIES + 2); // Each entry should be on a new line
 
     fs::remove_file(path).unwrap(); // Clean up after the test
+  }
+
+  #[tokio::test]
+  async fn test_append_and_flush_parallel() {
+    let temp_file = NamedTempFile::new().unwrap();
+    let path = temp_file.path().to_str().unwrap();
+    let wal = Arc::new(WriteAheadLog::new(path).unwrap());
+
+    const NUM_APPEND_THREADS: usize = 20;
+    const NUM_FLUSH_THREADS: usize = 10;
+    const NUM_APPENDS: usize = 50000; // Number of append operations per thread.
+    const NUM_FLUSHES: usize = 10; // Number of flush operations per thread.
+
+    // Spawn tasks for concurrent appends.
+    let mut append_handles = vec![];
+    for _ in 0..NUM_APPEND_THREADS {
+      let wal_clone = Arc::clone(&wal);
+      let handle = task::spawn(async move {
+        for _ in 0..NUM_APPENDS {
+          let entry = json!({"time": 1627590000, "message": "Concurrent append"});
+          wal_clone.append(entry).await.unwrap();
+        }
+      });
+      append_handles.push(handle);
+    }
+
+    // Spawn tasks for concurrent flushes.
+    let mut flush_handles = vec![];
+    for _ in 0..NUM_FLUSH_THREADS {
+      let wal_clone = Arc::clone(&wal);
+      let handle = task::spawn(async move {
+        for _ in 0..NUM_FLUSHES {
+          wal_clone.flush().await.unwrap();
+        }
+      });
+      flush_handles.push(handle);
+    }
+
+    // Await all append and flush tasks to ensure completion.
+    for handle in append_handles {
+      handle.await.unwrap();
+    }
+    for handle in flush_handles {
+      handle.await.unwrap();
+    }
+
+    // Final flush to ensure all entries are written.
+    wal.flush().await.unwrap();
+
+    // Verify that entries were written correctly.
+    let contents = fs::read_to_string(temp_file.path()).unwrap();
+    let num_lines = contents.matches('\n').count();
+    assert!(num_lines == NUM_APPENDS * NUM_APPEND_THREADS);
   }
 }

--- a/coredb/src/segment_manager/wal.rs
+++ b/coredb/src/segment_manager/wal.rs
@@ -5,7 +5,7 @@ use std::io::{BufWriter, Write};
 
 use crate::utils::error::CoreDBError;
 
-const MAX_ENTRIES: usize = 10000;
+const MAX_ENTRIES: usize = 1000;
 
 #[derive(Debug)]
 pub struct WriteAheadLog {
@@ -15,7 +15,9 @@ pub struct WriteAheadLog {
 
 impl WriteAheadLog {
   pub fn new(path: &str) -> Result<Self, CoreDBError> {
+    println!("#### Creatung new WAL");
     let file = OpenOptions::new().create(true).append(true).open(path)?;
+    println!("#### Created wal file");
     let writer = BufWriter::new(file);
 
     Ok(Self {
@@ -25,18 +27,19 @@ impl WriteAheadLog {
   }
 
   pub async fn append(&self, entry: Value) -> Result<(), CoreDBError> {
-    let num_entries;
+    //let num_entries;
 
     {
       // Write in a new scope to release buffer lock immediately.
-      let mut buffer = self.buffer.lock().await;
-      buffer.push(entry);
-      num_entries = buffer.len();
+      println!("#### Locking mutex");
+      let buffer = self.buffer.lock().await;
+      //buffer.push(entry);
+      //num_entries = buffer.len();
     }
 
-    if num_entries >= MAX_ENTRIES {
-      self.flush().await?;
-    }
+    //if num_entries >= MAX_ENTRIES {
+    //  self.flush().await?;
+    //}
     Ok(())
   }
 

--- a/coredb/src/segment_manager/wal.rs
+++ b/coredb/src/segment_manager/wal.rs
@@ -1,0 +1,96 @@
+use serde_json::Value;
+use std::fs::OpenOptions;
+use std::io::{BufWriter, Write};
+use std::sync::{Arc, Mutex};
+
+use crate::utils::error::CoreDBError;
+
+const MAX_ENTRIES: usize = 1000;
+
+#[derive(Debug)]
+pub struct WriteAheadLog {
+  buffer: Arc<Mutex<Vec<Value>>>,
+  writer: Arc<Mutex<BufWriter<std::fs::File>>>,
+}
+
+impl WriteAheadLog {
+  pub fn new(path: &str) -> Result<Self, CoreDBError> {
+    let file = OpenOptions::new().create(true).append(true).open(path)?;
+    let writer = BufWriter::new(file);
+
+    Ok(Self {
+      buffer: Arc::new(Mutex::new(Vec::new())),
+      writer: Arc::new(Mutex::new(writer)),
+    })
+  }
+
+  pub async fn append(&self, entry: Value) -> Result<(), CoreDBError> {
+    let mut buffer = self.buffer.lock().unwrap();
+    buffer.push(entry);
+
+    if buffer.len() >= MAX_ENTRIES {
+      drop(buffer); // Release the lock before flushing
+      self.flush().await?;
+    }
+    Ok(())
+  }
+
+  async fn flush(&self) -> Result<(), CoreDBError> {
+    let mut buffer = self.buffer.lock().unwrap();
+    let mut writer = self.writer.lock().unwrap();
+
+    for entry in buffer.iter() {
+      let line = serde_json::to_string(entry)? + "\n";
+      writer.write_all(line.as_bytes())?;
+    }
+    writer.flush()?;
+    buffer.clear();
+
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use serde_json::json;
+  use std::fs;
+  use std::path::Path;
+  use tempfile::NamedTempFile;
+
+  #[tokio::test]
+  async fn test_write_and_flush() {
+    // Create a new temporary file
+    let temp_file = NamedTempFile::new().unwrap();
+    let path = temp_file.path().to_str().unwrap();
+    let wal = WriteAheadLog::new(path).unwrap();
+
+    let entry = json!({"time": 1627590000, "message": "Test log entry"});
+
+    // Add 2 entries. wal.flash() is not called yet, so the file should not contain 'Test log entry'.
+    wal.append(entry.clone()).await.unwrap();
+    wal.append(entry.clone()).await.unwrap();
+    let contents = fs::read_to_string(Path::new(path)).unwrap();
+    assert!(!contents.contains("Test log entry"));
+
+    // Flush wal. File should now contain 'Test log entry' twice.
+    wal.flush().await.unwrap();
+    let contents = fs::read_to_string(Path::new(path)).unwrap();
+    assert!(contents.contains("Test log entry"));
+    assert_eq!(contents.matches('\n').count(), 2); // Each entry should be on a new line
+
+    // Add more entries, upto a total of MAX_ENTRIES.
+    for _ in 0..MAX_ENTRIES {
+      wal.append(entry.clone()).await.unwrap();
+    }
+
+    // Flush should be called automatically as we reach MAX_ENTRIES limit.
+
+    // Read back the log file. Should noe contain 'Test log entry' MAX_ENTRIES+2 times.
+    let contents = fs::read_to_string(Path::new(path)).unwrap();
+    assert!(contents.contains("Test log entry"));
+    assert_eq!(contents.matches('\n').count(), MAX_ENTRIES + 2); // Each entry should be on a new line
+
+    fs::remove_file(path).unwrap(); // Clean up after the test
+  }
+}

--- a/coredb/src/segment_manager/wal.rs
+++ b/coredb/src/segment_manager/wal.rs
@@ -1,4 +1,4 @@
-use std::fs::{remove_file, OpenOptions};
+use std::fs::{metadata, remove_file, OpenOptions};
 use std::io::{BufWriter, Write};
 
 use serde_json::Value;
@@ -53,8 +53,10 @@ impl WriteAheadLog {
   }
 
   pub fn remove(&mut self) -> Result<(), CoreDBError> {
-    // Delete the file.
-    remove_file(&self.file_path)?;
+    // Delete the file - if it exists.
+    if metadata(&self.file_path).is_ok() {
+      remove_file(&self.file_path)?
+    }
 
     Ok(())
   }

--- a/coredb/src/utils/config.rs
+++ b/coredb/src/utils/config.rs
@@ -36,6 +36,7 @@ const DEFAULT_CONFIG_FILE_NAME: &str = "default.toml";
 /// Settings for coredb.
 pub struct CoreDBSettings {
   index_dir_path: String,
+  wal_dir_path: String,
   default_index_name: String,
 
   log_messages_threshold: u32,
@@ -49,23 +50,32 @@ pub struct CoreDBSettings {
 }
 
 impl CoreDBSettings {
-  /// Get the settings for the directory where the index is stored.
-  pub fn get_index_dir_path(&self) -> String {
-    let path = Path::new(&self.index_dir_path);
+  fn get_absolute_path(input: &str) -> String {
+    let path = Path::new(input);
 
     if path.is_absolute() {
       // If the path is already absolute, return it as is.
-      self.index_dir_path.clone()
+      input.to_owned()
     } else {
       // If the path is relative, concatenate it with the current directory.
       let current_dir = env::current_dir().expect("Could not get current directory");
-      let joined_path = current_dir.join(path);
+      let joined_path = current_dir.join(input);
       joined_path
         .as_path()
         .to_str()
         .expect("Could not convert path to string")
         .to_owned()
     }
+  }
+
+  /// Get the settings for the directory where the index is stored.
+  pub fn get_index_dir_path(&self) -> String {
+    Self::get_absolute_path(&self.index_dir_path)
+  }
+
+  /// Get the settings for the directory where the write ahead log is stored.
+  pub fn get_wal_dir_path(&self) -> String {
+    Self::get_absolute_path(&self.wal_dir_path)
   }
 
   /// Get the settings for the default index name.
@@ -237,6 +247,7 @@ mod tests {
       file
         .write_all(b"index_dir_path = \"/var/index\"\n")
         .unwrap();
+      file.write_all(b"wal_dir_path = \"/var/wal\"\n").unwrap();
       file
         .write_all(b"default_index_name = \".default\"\n")
         .unwrap();
@@ -257,6 +268,7 @@ mod tests {
     let settings = Settings::new(config_dir_path).unwrap();
     let coredb_settings = settings.get_coredb_settings();
     assert_eq!(coredb_settings.get_index_dir_path(), "/var/index");
+    assert_eq!(coredb_settings.get_wal_dir_path(), "/var/wal");
     assert_eq!(coredb_settings.get_default_index_name(), ".default");
     assert_eq!(
       coredb_settings.get_search_memory_budget_bytes(),

--- a/coredb/src/utils/sync.rs
+++ b/coredb/src/utils/sync.rs
@@ -16,6 +16,7 @@ pub(crate) use loom::thread;
 // https://github.com/tokio-rs/loom/blob/16e5e9a0e562cf754ced04ac1a82802b8e492178/src/rt/notify.rs#L113
 // Once this is fixed, we can use loom::sync::RwLock when configuration is loom (and use std::sync::RwLock
 // when the configuration isn't loom).
+pub(crate) use parking_lot::Mutex;
 pub(crate) use parking_lot::RwLock;
 
 // Tokio Mutex and RwLock - needed when we need lock to be Send + Sync.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -846,6 +846,7 @@ mod tests {
   fn create_test_config(
     config_dir_path: &str,
     index_dir_path: &str,
+    wal_dir_path: &str,
     container_name: &str,
     use_rabbitmq: bool,
   ) {
@@ -856,6 +857,7 @@ mod tests {
       get_joined_path(config_dir_path, Settings::get_default_config_file_name());
     {
       let index_dir_path_line = format!("index_dir_path = \"{}\"\n", index_dir_path);
+      let wal_dir_path_line = format!("wal_dir_path = \"{}\"\n", wal_dir_path);
       let default_index_name = format!("default_index_name = \"{}\"\n", ".default");
       let container_name_line = format!("container_name = \"{}\"\n", container_name);
       let use_rabbitmq_str = use_rabbitmq
@@ -874,6 +876,7 @@ mod tests {
       // Write coredb section.
       file.write_all(b"[coredb]\n").unwrap();
       file.write_all(index_dir_path_line.as_bytes()).unwrap();
+      file.write_all(wal_dir_path_line.as_bytes()).unwrap();
       file.write_all(default_index_name.as_bytes()).unwrap();
       file.write_all(b"log_messages_threshold = 1000\n").unwrap();
       file.write_all(b"metric_points_threshold = 1000\n").unwrap();
@@ -1179,11 +1182,14 @@ mod tests {
     let config_dir_path = config_dir.path().to_str().unwrap();
     let index_dir = TempDir::new("index_test").unwrap();
     let index_dir_path = index_dir.path().to_str().unwrap();
+    let wal_dir = TempDir::new("wal_test").unwrap();
+    let wal_dir_path = wal_dir.path().to_str().unwrap();
     let container_name = "infino-test-main-rs";
 
     create_test_config(
       config_dir_path,
       index_dir_path,
+      wal_dir_path,
       container_name,
       use_rabbitmq,
     );
@@ -1360,9 +1366,17 @@ mod tests {
     let config_dir_path = config_dir.path().to_str().unwrap();
     let index_dir = TempDir::new("index_test").unwrap();
     let index_dir_path = index_dir.path().to_str().unwrap();
+    let wal_dir = TempDir::new("wal_test").unwrap();
+    let wal_dir_path = wal_dir.path().to_str().unwrap();
     let container_name = "infino-test-main-rs";
 
-    create_test_config(config_dir_path, index_dir_path, container_name, false);
+    create_test_config(
+      config_dir_path,
+      index_dir_path,
+      wal_dir_path,
+      container_name,
+      false,
+    );
 
     // Create the app.
     let (mut app, _, _) = app(config_dir_path, "rabbitmq", "3").await;
@@ -1414,6 +1428,8 @@ mod tests {
     let config_dir_path = config_dir.path().to_str().unwrap();
     let index_dir = TempDir::new("index_test").unwrap();
     let index_dir_path = index_dir.path().to_str().unwrap();
+    let wal_dir = TempDir::new("wal_test").unwrap();
+    let wal_dir_path = wal_dir.path().to_str().unwrap();
     let container_name = "infino-test-main-rs";
     let storage = Storage::new(&StorageType::Local)
       .await
@@ -1422,6 +1438,7 @@ mod tests {
     create_test_config(
       config_dir_path,
       index_dir_path,
+      wal_dir_path,
       container_name,
       use_rabbitmq,
     );

--- a/server/tests/startup.rs
+++ b/server/tests/startup.rs
@@ -18,7 +18,7 @@ fn test_cargo_run_infino() {
     .spawn()
     .expect("Failed to start process");
 
-  // Wait for 60 seconds.
+  // Wait for 30 seconds.
   thread::sleep(Duration::from_secs(30));
 
   // Check if the process is still running - fail in case the server isn't running.


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Implement write ahead log, and store any logs/metrics in write ahead log (WAL) first before writing them to the segment.

Note that we don't yet read the WAL at startup and recover any lost data - that change is coming up in a subsequent PR.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
