### PR TITLE
Multiple index support. 

### DIFF
--- a/benches/config/default.toml
+++ b/benches/config/default.toml
@@ -1,6 +1,6 @@
 [coredb]
 index_dir_path = "index"
-default_index_name = ".default"
+default_index_name = "default"
 num_log_messages_threshold = 100000
 num_metric_points_threshold = 100000
 retention_days = 30

--- a/benches/src/logs/infino.rs
+++ b/benches/src/logs/infino.rs
@@ -46,6 +46,7 @@ impl InfinoEngine {
         }
         if let Ok(message) = line {
           self.coredb.append_log_message(
+            "default",
             Utc::now().timestamp_millis() as u64,
             &HashMap::new(),
             message.as_str(),
@@ -69,7 +70,7 @@ impl InfinoEngine {
 
     match self
       .coredb
-      .search_logs(query, "", range_start_time, range_end_time)
+      .search_logs("default", query, "", range_start_time, range_end_time)
       .await
     {
       Ok(result) => {

--- a/benches/src/logs/infino_rest.rs
+++ b/benches/src/logs/infino_rest.rs
@@ -51,7 +51,7 @@ impl InfinoApiClient {
           logs_batch.push(log);
           if num_docs_in_this_batch == num_docs_per_batch {
             let _ = client
-              .post("http://localhost:3000/append_log")
+              .post("http://localhost:3000/default/append_log")
               .header("Content-Type", "application/json")
               .body(Body::from(serde_json::to_string(&logs_batch).unwrap()))
               .send()

--- a/benches/src/metrics/infino.rs
+++ b/benches/src/metrics/infino.rs
@@ -25,7 +25,7 @@ impl InfinoMetricsClient {
         let json_str = format!("{{\"date\": {}, \"{}\":{}}}", time, "cpu_usage", value);
         let client = reqwest::Client::new();
         let res = client
-          .post("http://localhost:3000/append_metric")
+          .post("http://localhost:3000/default/append_metric")
           .header("Content-Type", "application/json")
           .body(json_str)
           .send()
@@ -50,7 +50,7 @@ impl InfinoMetricsClient {
 
   pub async fn search_metrics(&self) -> u128 {
     let query_url =
-      "http://localhost:3000/search_metrics?label_name=__name__&&label_value=cpu_usage&start_time=0";
+      "http://localhost:3000/default/search_metrics?label_name=__name__&&label_value=cpu_usage&start_time=0";
     let now = Instant::now();
     let response = reqwest::get(query_url).await;
     let elapsed = now.elapsed();

--- a/clients/infinopy/infinopy/client.py
+++ b/clients/infinopy/infinopy/client.py
@@ -18,40 +18,29 @@ class InfinoClient:
         path = "/ping"
         return self._request("GET", path)
 
-    def append_log(self, payload):
-        path = "/append_log"
+    def append_log(self, index_name, payload):
+        path = "/" + index_name + "/append_log"
         return self._request("POST", path, json=payload)
 
-    # Deprecated. Kept here for backwards compatibility. TODO: Remove by Jan 2024.
-    def append_ts(self, payload):
-        return self.append_metric(payload)
-
-    def append_metric(self, payload):
-        path = "/append_metric"
+    def append_metric(self, index_name, payload):
+        path = "/" + index_name + "/append_metric"
         return self._request("POST", path, json=payload)
 
-    # Deprecated. Kept here for backwards compatibility. TODO: Remove by Jan 2024.
-    def search_log(self, text, start_time=None, end_time=None):
-        return self.search_logs(text, start_time, end_time)
-
-    def search_logs(self, text, start_time=None, end_time=None):
-        path = "/search_logs"
+    def search_logs(self, index_name, text, start_time=None, end_time=None):
+        path = "/" + index_name + "/search_logs"
         params = {"text": text, "start_time": start_time, "end_time": end_time}
         response = self._request("GET", path, params=params)
         return response
 
-    def summarize(self, text, start_time=None, end_time=None):
-        path = "/summarize"
+    def summarize(self, index_name, text, start_time=None, end_time=None):
+        path = "/" + index_name + "/summarize"
         params = {"text": text, "start_time": start_time, "end_time": end_time}
         response = self._request("GET", path, params=params)
         return response
 
-    # Deprecated. Kept here for backwards compatibility. TODO: Remove by Jan 2024.
-    def search_ts(self, label_name, label_value, start_time=None, end_time=None):
-        return self.search_metrics(label_name, label_value, start_time, end_time)
 
-    def search_metrics(self, label_name, label_value, start_time=None, end_time=None):
-        path = "/search_metrics"
+    def search_metrics(self, index_name, label_name, label_value, start_time=None, end_time=None):
+        path = "/" + index_name + "/search_metrics"
         params = {
             "label_name": label_name,
             "label_value": label_value,
@@ -60,8 +49,8 @@ class InfinoClient:
         }
         return self._request("GET", path, params=params)
 
-    def get_index_dir(self):
-        path = "/get_index_dir"
+    def get_index_dir(self, index_name):
+        path = "/" + index_name + "/get_index_dir"
         return self._request("GET", path)
 
     def get_base_url(self):

--- a/clients/infinopy/tests/test_client.py
+++ b/clients/infinopy/tests/test_client.py
@@ -44,16 +44,16 @@ class InfinoClientTestCase(unittest.TestCase):
 
         # Test the append_log method
         payload = {"date": current_time, "message": "my message one"}
-        response = self.client.append_log(payload)
+        response = self.client.append_log("default", payload)
         self.assertEqual(response.status_code, 200)
 
         payload = {"date": current_time, "message": "my message two"}
-        response = self.client.append_log(payload)
+        response = self.client.append_log("default", payload)
         self.assertEqual(response.status_code, 200)
 
         # Test the search_logs method.
         # Query for text that is present in both the payloads.
-        response = self.client.search_logs(
+        response = self.client.search_logs("default",
             text="my message", start_time=current_time - 10, end_time=current_time + 10
         )
         self.assertEqual(response.status_code, 200)
@@ -61,7 +61,7 @@ class InfinoClientTestCase(unittest.TestCase):
         self.assertEqual(len(results), 2)
 
         # Test backwards-compatibility
-        response = self.client.search_log(
+        response = self.client.search_log("default",
             text="my message", start_time=current_time - 10, end_time=current_time + 10
         )
         self.assertEqual(response.status_code, 200)
@@ -69,7 +69,7 @@ class InfinoClientTestCase(unittest.TestCase):
         self.assertEqual(len(results), 2)
 
         # Query for text that is present in only one payload.
-        response = self.client.search_logs(
+        response = self.client.search_logs("default",
             text="two", start_time=current_time - 10, end_time=current_time + 10
         )
         self.assertEqual(response.status_code, 200)
@@ -77,14 +77,14 @@ class InfinoClientTestCase(unittest.TestCase):
         self.assertEqual(len(results), 1)
 
         # Test that default values for start and end time work.
-        response = self.client.search_logs(text="my message")
+        response = self.client.search_logs("default", text="my message")
         self.assertEqual(response.status_code, 200)
         results = response.json()
         self.assertEqual(len(results), 2)
 
         # Test the summarize api.
         # We haven't set OPENAI_API_KEY while starting the container, so this should fail.
-        response = self.client.summarize(
+        response = self.client.summarize("default",
           text="my message",
           start_time=current_time - 10,
           end_time=current_time + 10,
@@ -96,20 +96,15 @@ class InfinoClientTestCase(unittest.TestCase):
 
         # Test the append_metric method.
         payload = {"date": current_time, "some_metric_name": 1.0}
-        response = self.client.append_metric(payload)
+        response = self.client.append_metric("default", payload)
         self.assertEqual(response.status_code, 200)
 
         payload = {"date": current_time + 1, "some_metric_name": 0.0}
-        response = self.client.append_metric(payload)
-        self.assertEqual(response.status_code, 200)
-
-        # Test backwards-compatibility
-        payload = {"date": current_time, "some_metric_name": 2.0}
-        response = self.client.append_ts(payload)
+        response = self.client.append_metric("default", payload)
         self.assertEqual(response.status_code, 200)
 
         # Test the search_metrics method.
-        response = self.client.search_metrics(
+        response = self.client.search_metrics("default",
             label_name="__name__",
             label_value="some_metric_name",
             start_time=current_time - 10,
@@ -120,20 +115,9 @@ class InfinoClientTestCase(unittest.TestCase):
         self.assertEqual(len(results), 3)
 
         # Test that default values for start and end time work.
-        response = self.client.search_metrics(
+        response = self.client.search_metrics("default",
             label_name="__name__",
             label_value="some_metric_name",
-        )
-        self.assertEqual(response.status_code, 200)
-        results = response.json()
-        self.assertEqual(len(results), 3)
-
-        # Test backwards-compatibility
-        response = self.client.search_ts(
-            label_name="__name__",
-            label_value="some_metric_name",
-            start_time=current_time - 10,
-            end_time=current_time + 10,
         )
         self.assertEqual(response.status_code, 200)
         results = response.json()
@@ -141,9 +125,9 @@ class InfinoClientTestCase(unittest.TestCase):
     
     def test_get_index_dir(self):
         # Test the get_index_dir method.
-        response = self.client.get_index_dir()
+        response = self.client.get_index_dir("default")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.text, "data/.default")
+        self.assertEqual(response.text, "data/default")
 
     def test_base_url(self):
         # Check default base url

--- a/config/default.toml
+++ b/config/default.toml
@@ -6,7 +6,7 @@ index_dir_path = "data"
 # "cloud_storage_region" can be used to set a region for the cloud provider
 
 ### Index configuration.
-default_index_name = ".default"
+default_index_name = "default"
 
 # Maximum number of log messages or metric points in a segment during appends. A new segment
 # will be created after these thresholds are reached.

--- a/coredb/src/lib.rs
+++ b/coredb/src/lib.rs
@@ -138,9 +138,13 @@ impl CoreDB {
     }
   }
 
-  /// Append a log message.
+  pub fn get_index_map(&self) -> &DashMap<String, Index> {
+    &self.index_map
+  }
+
   pub async fn append_log_message(
     &self,
+    index_name: &str,
     time: u64,
     fields: &HashMap<String, String>,
     text: &str,
@@ -149,18 +153,19 @@ impl CoreDB {
       "Appending log message in CoreDB: time {}, fields {:?}, text {}",
       time, fields, text
     );
-    self
+
+    let index = self
       .index_map
-      .get(self.get_default_index_name())
-      .unwrap()
-      .value()
-      .append_log_message(time, fields, text)
-      .await
+      .get(index_name)
+      .ok_or(QueryError::IndexNotFoundError(index_name.to_string()))?;
+
+    index.append_log_message(time, fields, text).await
   }
 
   /// Append a metric point.
   pub async fn append_metric_point(
     &self,
+    index_name: &str,
     metric_name: &str,
     labels: &HashMap<String, String>,
     time: u64,
@@ -170,36 +175,35 @@ impl CoreDB {
       "Appending metric point in CoreDB: time {}, value {}, labels {:?}, name {}",
       time, value, labels, metric_name
     );
-    self
+
+    let index = self
       .index_map
-      .get(self.get_default_index_name())
-      .unwrap()
-      .value()
+      .get(index_name)
+      .ok_or(QueryError::IndexNotFoundError(index_name.to_string()))?;
+
+    index
       .append_metric_point(metric_name, labels, time, value)
       .await
   }
 
   /// Search the log messages for given query and range.
   ///
-  /// Infino log searches support Lucene Query Syntax: https://lucene.apache.org/core/2_9_4/queryparsersyntax.html
-  /// http://infino-endpoint?"my lucene query"&start_time=blah&end_time=blah
-  ///
-  /// but these can be overridden by a Query DSL in the
-  /// json body sent with the query: https://opensearch.org/docs/latest/query-dsl/.
+  /// https://opensearch.org/docs/latest/query-dsl/.
   ///
   /// Note that while the query terms are not required in the URL, the query parameters
   /// "start_time" and "end_time" are indeed required in the URL. They are always added by the
   /// OpenSearch plugin that calls Infino.
   pub async fn search_logs(
     &self,
+    index_name: &str,
     url_query: &str,
     json_query: &str,
     range_start_time: u64,
     range_end_time: u64,
   ) -> Result<QueryDSLObject, CoreDBError> {
     debug!(
-      "COREDB: Search logs for URL query: {:?}, JSON query: {:?}, range_start_time: {}, range_end_time: {}",
-      url_query, json_query, range_start_time, range_end_time
+      "COREDB: Search logs for index name: {}, URL query: {:?}, JSON query: {:?}, range_start_time: {}, range_end_time: {}",
+      index_name, url_query, json_query, range_start_time, range_end_time
     );
 
     let mut json_query = json_query.to_string();
@@ -211,6 +215,7 @@ impl CoreDB {
     // If no JSON query, convert the URL query to Query DSL or return an error if no URL query
     if is_json_empty {
       if is_url_empty {
+        debug!("No Query was provided. Exiting");
         return Err(QueryError::NoQueryProvided.into());
       } else {
         // Update json_query with the constructed query from url_query
@@ -226,11 +231,13 @@ impl CoreDB {
 
     let index = self
       .index_map
-      .get(self.get_default_index_name())
-      .ok_or(QueryError::NoQueryProvided)?;
+      .get(index_name)
+      .ok_or(QueryError::IndexNotFoundError(format!(
+        "Can't find index {}",
+        index_name,
+      )))?;
 
     index
-      .value()
       .search_logs(&ast, range_start_time, range_end_time)
       .await
   }
@@ -239,6 +246,7 @@ impl CoreDB {
   /// Range boundaries can be overridden by PromQL query in the JSON body
   pub async fn search_metrics(
     &self,
+    index_name: &str,
     url_query: &str,
     json_query: &str,
     timeout: u64,
@@ -254,48 +262,52 @@ impl CoreDB {
     // TODO: for now we'll ignore the json body but come back to this
     let ast = Index::parse_query(url_query)?;
 
-    self
+    let index = self
       .index_map
-      .get(self.get_default_index_name())
-      .unwrap()
-      .value()
+      .get(index_name)
+      .ok_or(QueryError::IndexNotFoundError(index_name.to_string()))?;
+
+    index
       .search_metrics(&ast, timeout, range_start_time, range_end_time)
       .await
   }
 
   /// Commit the index to disk.
-  pub async fn commit(&self, commit_current_segment: bool) -> Result<(), CoreDBError> {
-    self
+  pub async fn commit(
+    &self,
+    index_name: &str,
+    commit_current_segment: bool,
+  ) -> Result<(), CoreDBError> {
+    debug!("COREDB: Commiting index {}", index_name);
+
+    let index = self
       .index_map
-      .get(self.get_default_index_name())
-      .unwrap()
-      .value()
-      .commit(commit_current_segment)
-      .await
+      .get(index_name)
+      .ok_or(QueryError::IndexNotFoundError(index_name.to_string()))?;
+
+    index.value().commit(commit_current_segment).await
   }
 
-  /// Refresh the default index from the given directory path.
-  // TODO: what to do if there are multiple indices?
-  pub async fn refresh(config_dir_path: &str) -> Result<Self, CoreDBError> {
+  /// Refresh the index from the given directory path.
+  pub async fn refresh(index_name: &str, config_dir_path: &str) -> Result<Self, CoreDBError> {
     // Read the settings and the index directory path.
     let settings = Settings::new(config_dir_path).unwrap();
     let coredb_settings = settings.get_coredb_settings();
     let index_dir_path = coredb_settings.get_index_dir_path();
-    let default_index_name = coredb_settings.get_default_index_name();
-    let default_index_dir_path = format!("{}/{}", index_dir_path, default_index_name);
+    let actual_index_path = format!("{}/{}", index_dir_path, index_name);
     let search_memory_budget_bytes = coredb_settings.get_search_memory_budget_bytes();
     let storage_type = coredb_settings.get_storage_type()?;
 
     // Refresh the index.
     let index = Index::refresh(
       &storage_type,
-      &default_index_dir_path,
+      &actual_index_path,
       search_memory_budget_bytes,
     )
     .await?;
 
     let index_map = DashMap::new();
-    index_map.insert(default_index_name.to_string(), index);
+    index_map.insert(index_name.to_string(), index);
 
     let retention_period = settings.get_coredb_settings().get_retention_days();
     let policy = Box::new(TimeBasedRetention::new(retention_period));
@@ -308,10 +320,10 @@ impl CoreDB {
   }
 
   /// Get the directory where the index is stored.
-  pub fn get_index_dir(&self) -> String {
+  pub fn get_index_dir(&self, index_name: &str) -> String {
     self
       .index_map
-      .get(self.get_default_index_name())
+      .get(index_name)
       .unwrap()
       .value()
       .get_index_dir()
@@ -371,9 +383,8 @@ impl CoreDB {
   }
 
   /// Function to help with triggering the retention policy
-  pub async fn trigger_retention(&self) -> Result<(), CoreDBError> {
-    let default_index_name = self.get_default_index_name();
-    let temp_reference = self.index_map.get(default_index_name).unwrap();
+  pub async fn trigger_retention(&self, index_name: &str) -> Result<(), CoreDBError> {
+    let temp_reference = self.index_map.get(index_name).unwrap();
     let index = temp_reference.value();
 
     // TODO: this does not need to read all_segments_summaries from disk - can use the one already
@@ -408,7 +419,7 @@ mod tests {
   use super::*;
 
   /// Helper function to create a test configuration.
-  fn create_test_config(config_dir_path: &str, index_dir_path: &str) {
+  fn create_test_config(index_name: &str, config_dir_path: &str, index_dir_path: &str) {
     // Create a test config in the directory config_dir_path.
     let config_file_path = get_joined_path(
       config_dir_path,
@@ -417,7 +428,7 @@ mod tests {
 
     {
       let index_dir_path_line = format!("index_dir_path = \"{}\"\n", index_dir_path);
-      let default_index_name_line = format!("default_index_name = \"{}\"\n", ".default");
+      let default_index_name_line = format!("default_index_name = \"{}\"\n", index_name);
 
       let mut file = std::fs::File::create(config_file_path).unwrap();
       file.write_all(b"[coredb]\n").unwrap();
@@ -442,9 +453,10 @@ mod tests {
   async fn test_coredb_basic() -> Result<(), CoreDBError> {
     let config_dir = TempDir::new("config_test").unwrap();
     let config_dir_path = config_dir.path().to_str().unwrap();
-    let index_dir = TempDir::new("index_test").unwrap();
+    let index_name = "index_test";
+    let index_dir = TempDir::new(index_name).unwrap();
     let index_dir_path = index_dir.path().to_str().unwrap();
-    create_test_config(config_dir_path, index_dir_path);
+    create_test_config(index_name, config_dir_path, index_dir_path);
     println!("Config dir path {}", config_dir_path);
 
     // Create a new coredb instance.
@@ -457,6 +469,7 @@ mod tests {
     // Add a few log messages.
     coredb
       .append_log_message(
+        index_name,
         Utc::now().timestamp_millis() as u64,
         &HashMap::new(),
         "log message 1",
@@ -465,6 +478,7 @@ mod tests {
       .expect("Could not append log message");
     coredb
       .append_log_message(
+        index_name,
         Utc::now().timestamp_millis() as u64 + 1, // Add a +1 to make the test predictable.
         &HashMap::new(),
         "log message 2",
@@ -475,6 +489,7 @@ mod tests {
     // Add a few metric points.
     coredb
       .append_metric_point(
+        index_name,
         "some_metric",
         &HashMap::new(),
         Utc::now().timestamp_millis() as u64,
@@ -484,6 +499,7 @@ mod tests {
       .expect("Could not append metric point");
     coredb
       .append_metric_point(
+        index_name,
         "some_metric",
         &HashMap::new(),
         Utc::now().timestamp_millis() as u64 + 1, // Add a +1 to make the test predictable.
@@ -492,17 +508,23 @@ mod tests {
       .await
       .expect("Could not append metric point");
 
-    coredb.commit(true).await.expect("Could not commit");
-    let coredb = CoreDB::refresh(config_dir_path).await?;
+    coredb
+      .commit(index_name, true)
+      .await
+      .expect("Could not commit");
+    let coredb = CoreDB::refresh(index_name, config_dir_path).await?;
 
     let end = Utc::now().timestamp_millis() as u64;
 
     // Search for log messages. The order of results should be reverse chronological order.
-    if let Err(err) = coredb.search_logs("message", "", start, end).await {
+    if let Err(err) = coredb
+      .search_logs(index_name, "message", "", start, end)
+      .await
+    {
       eprintln!("Error in search_logs: {:?}", err);
     } else {
       let results = coredb
-        .search_logs("message", "", start, end)
+        .search_logs(index_name, "message", "", start, end)
         .await
         .expect("Error in search_logs");
       assert_eq!(
@@ -527,7 +549,7 @@ mod tests {
 
     // Search for metric points.
     let mut results = coredb
-      .search_metrics("some_metric", "", 0, start, end)
+      .search_metrics(index_name, "some_metric", "", 0, start, end)
       .await
       .expect("Error in get_metrics");
 
@@ -539,7 +561,7 @@ mod tests {
     assert_eq!(mp[1].get_value(), 2.0);
 
     coredb
-      .trigger_retention()
+      .trigger_retention(index_name)
       .await
       .expect("Error in retention policy");
 

--- a/coredb/src/segment_manager/search_logs.rs
+++ b/coredb/src/segment_manager/search_logs.rs
@@ -135,7 +135,8 @@ impl Serialize for QueryLogMessage {
     let log_message = &self.message;
     let mut map = serializer.serialize_map(None)?;
 
-    map.serialize_entry("_index", &"your_index_name_here")?;
+    //TODO: Inject the index name
+    map.serialize_entry("_index", "DUMMY")?;
     map.serialize_entry("_id", &self.id)?;
     map.serialize_entry("_score", &1.0)?;
 

--- a/coredb/src/utils/config.rs
+++ b/coredb/src/utils/config.rs
@@ -238,7 +238,7 @@ mod tests {
         .write_all(b"index_dir_path = \"/var/index\"\n")
         .unwrap();
       file
-        .write_all(b"default_index_name = \".default\"\n")
+        .write_all(b"default_index_name = \"default\"\n")
         .unwrap();
       file.write_all(b"log_messages_threshold = 1000\n").unwrap();
       file
@@ -257,7 +257,7 @@ mod tests {
     let settings = Settings::new(config_dir_path).unwrap();
     let coredb_settings = settings.get_coredb_settings();
     assert_eq!(coredb_settings.get_index_dir_path(), "/var/index");
-    assert_eq!(coredb_settings.get_default_index_name(), ".default");
+    assert_eq!(coredb_settings.get_default_index_name(), "default");
     assert_eq!(
       coredb_settings.get_search_memory_budget_bytes(),
       4096 * 1024 * 1024
@@ -294,7 +294,7 @@ mod tests {
         coredb_settings.get_search_memory_budget_bytes(),
         4 * 1024 * 1024
       );
-      assert_eq!(coredb_settings.get_default_index_name(), ".default");
+      assert_eq!(coredb_settings.get_default_index_name(), "default");
     }
   }
 
@@ -312,7 +312,7 @@ mod tests {
         .write_all(b"index_dir_path = \"/var/index\"\n")
         .unwrap();
       file
-        .write_all(b"default_index_name = \".default\"\n")
+        .write_all(b"default_index_name = \"default\"\n")
         .unwrap();
       file
         .write_all(b"search_memory_budget_megabytes = 2048\n")

--- a/coredb/src/utils/error.rs
+++ b/coredb/src/utils/error.rs
@@ -78,6 +78,9 @@ pub enum QueryError {
   #[error("Combiner failure: {0}")]
   CombinerFailure(String),
 
+  #[error("Index not found error: {0}")]
+  IndexNotFoundError(String),
+
   #[error("Traverse error: {0}")]
   TraverseError(String),
 

--- a/server/src/commit.rs
+++ b/server/src/commit.rs
@@ -15,37 +15,17 @@ pub async fn commit_in_loop(state: Arc<AppState>) {
   let policy_interval_ms = 3600000; // 1hr in ms
   loop {
     let is_shutdown = IS_SHUTDOWN.load();
-
-    // Commit the indexes to object store. Set commit_current_segment to is_shutdown -- i.e.,
+    // Commit the index to object store. Set commit_current_segment to is_shutdown -- i.e.,
     // commit the current segment only when the server is shutting down.
     let state_clone = state.clone();
     let is_shutdown_clone = is_shutdown;
     let commit_handle = tokio::spawn(async move {
-      for index_entry in state_clone.coredb.get_index_map().iter() {
-        let index = index_entry.value();
-        let index_name = index_entry.key();
-        let result = index.commit(is_shutdown_clone).await;
-        // Handle the result of the commit operation
-        match result {
-          Ok(_) => debug!("Commit for index {} successful", index_name),
-          Err(e) => error!("Commit failed for index {}: {}", index_name, e),
-        }
+      let result = state_clone.coredb.commit(is_shutdown_clone).await;
 
-        let current_time = Utc::now().timestamp_millis() as u64;
-        // TODO: make trigger policy interval configurable
-        if current_time - last_trigger_policy_time > policy_interval_ms {
-          info!("Triggering retention policy on index in coredb");
-          let result = state_clone.coredb.trigger_retention(index_name).await;
-
-          if let Err(e) = result {
-            error!(
-              "Error triggering retention policy on index in coredb: {}",
-              e
-            );
-          }
-
-          last_trigger_policy_time = current_time;
-        }
+      // Handle the result of the commit operation
+      match result {
+        Ok(_) => debug!("Commit successful"),
+        Err(e) => error!("Commit failed: {}", e),
       }
     });
 
@@ -64,6 +44,19 @@ pub async fn commit_in_loop(state: Arc<AppState>) {
       break;
     }
 
+    let current_time = Utc::now().timestamp_millis() as u64;
+    // TODO: make trigger policy interval configurable
+    if current_time - last_trigger_policy_time > policy_interval_ms {
+      info!("Triggering retention policy on index in coredb");
+      let result = state.coredb.trigger_retention().await;
+      if let Err(e) = result {
+        error!(
+          "Error triggering retention policy on index in coredb: {}",
+          e
+        );
+      }
+      last_trigger_policy_time = current_time;
+    }
     // Sleep for some time before committing again.
     sleep(Duration::from_millis(1000)).await;
   } // end loop {..}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -169,18 +169,18 @@ async fn app(
   // Build our application with a route
   let router: Router = Router::new()
     // GET methods
-    .route("/get_index_dir", get(get_index_dir))
+    .route("/:index_name/get_index_dir", get(get_index_dir))
     .route("/ping", get(ping))
     .route("/", get(ping))
-    .route("/search_logs", get(search_logs))
-    .route("/search_metrics", get(search_metrics))
-    .route("/summarize", get(summarize))
+    .route("/:index_name/search_logs", get(search_logs))
+    .route("/:index_name/search_metrics", get(search_metrics))
+    .route("/:index_name/summarize", get(summarize))
     //---
     // POST methods
     // TODO: all the APIs should have index name
-    .route("/append_log", post(append_log))
-    .route("/append_metric", post(append_metric))
-    .route("/flush", post(flush))
+    .route("/:index_name/append_log", post(append_log))
+    .route("/:index_name/append_metric", post(append_metric))
+    .route("/:index_name/flush", post(flush))
     // POST methods to create and delete index
     .route("/:index_name", put(create_index))
     .route("/:index_name", delete(delete_index))
@@ -326,6 +326,7 @@ fn get_timestamp(value: &Map<String, Value>, timestamp_key: &str) -> Result<u64,
 /// Append log data to CoreDB.
 async fn append_log(
   State(state): State<Arc<AppState>>,
+  Path(index_name): Path<String>,
   Json(log_json): Json<serde_json::Value>,
 ) -> Result<(), (StatusCode, String)> {
   debug!("Appending log entry {}", log_json);
@@ -386,17 +387,15 @@ async fn append_log(
 
     let result = state
       .coredb
-      .append_log_message(timestamp, &fields, &text)
+      .append_log_message(&index_name, timestamp, &fields, &text)
       .await;
 
     if let Err(error) = result {
       match error {
         CoreDBError::TooManyAppendsError() => {
-          // Handle the TooManyAppendsError specifically
           return Err((StatusCode::TOO_MANY_REQUESTS, error.to_string()));
         }
         _ => {
-          // Catch-all for other errors
           println!("An unexpected error occurred.");
         }
       }
@@ -409,6 +408,7 @@ async fn append_log(
 /// Append metric data to CoreDB.
 async fn append_metric(
   State(state): State<Arc<AppState>>,
+  Path(index_name): Path<String>,
   Json(ts_json): Json<serde_json::Value>,
 ) -> Result<(), (StatusCode, String)> {
   debug!("Appending metric entry: {:?}", ts_json);
@@ -483,17 +483,15 @@ async fn append_metric(
 
         let result = state
           .coredb
-          .append_metric_point(key, &labels, timestamp, value_f64)
+          .append_metric_point(&index_name, key, &labels, timestamp, value_f64)
           .await;
 
         if let Err(error) = result {
           match error {
             CoreDBError::TooManyAppendsError() => {
-              // Handle the TooManyAppendsError specifically
               return Err((StatusCode::TOO_MANY_REQUESTS, error.to_string()));
             }
             _ => {
-              // Catch-all for other errors
               println!("An unexpected error occurred.");
             }
           }
@@ -509,6 +507,7 @@ async fn append_metric(
 async fn search_logs(
   State(state): State<Arc<AppState>>,
   Query(logs_query): Query<LogsQuery>,
+  Path(index_name): Path<String>,
   json_body: String,
 ) -> Result<String, (StatusCode, String)> {
   debug!(
@@ -520,6 +519,7 @@ async fn search_logs(
   let results = state
     .coredb
     .search_logs(
+      &index_name,
       &logs_query.text,
       &json_body,
       logs_query.start_time.unwrap_or(0),
@@ -542,6 +542,9 @@ async fn search_logs(
           match search_logs_error {
             QueryError::JsonParseError(_) => {
               Err((StatusCode::BAD_REQUEST, "Invalid JSON input".to_string()))
+            }
+            QueryError::IndexNotFoundError(_) => {
+              Err((StatusCode::BAD_REQUEST, "Could not find index".to_string()))
             }
             QueryError::TimeOutError(_) => Err((
               StatusCode::INTERNAL_SERVER_ERROR,
@@ -568,6 +571,7 @@ async fn search_logs(
 async fn summarize(
   State(state): State<Arc<AppState>>,
   Query(summarize_query): Query<SummarizeQuery>,
+  Path(index_name): Path<String>,
   json_body: String,
 ) -> Result<String, (StatusCode, String)> {
   debug!(
@@ -582,6 +586,7 @@ async fn summarize(
   let results = state
     .coredb
     .search_logs(
+      &index_name,
       &summarize_query.text,
       &json_body,
       summarize_query.start_time.unwrap_or(0),
@@ -650,6 +655,7 @@ async fn summarize(
 async fn search_metrics(
   State(state): State<Arc<AppState>>,
   Query(metrics_query): Query<MetricsQuery>,
+  Path(index_name): Path<String>,
   json_body: String,
 ) -> impl IntoResponse {
   debug!("MAIN: Search metrics for HTTP query: {:?}", metrics_query);
@@ -681,6 +687,7 @@ async fn search_metrics(
   let results = state
     .coredb
     .search_metrics(
+      &index_name,
       text_ref,
       &json_body,
       timeout.num_seconds() as u64,
@@ -746,8 +753,11 @@ async fn search_metrics(
 }
 
 /// Flush the index to disk.
-async fn flush(State(state): State<Arc<AppState>>) -> Result<(), (StatusCode, String)> {
-  let result = state.coredb.commit(true).await;
+async fn flush(
+  State(state): State<Arc<AppState>>,
+  Path(index_name): Path<String>,
+) -> Result<(), (StatusCode, String)> {
+  let result = state.coredb.commit(&index_name, true).await;
 
   match result {
     Ok(result) => Ok(result),
@@ -761,8 +771,11 @@ async fn flush(State(state): State<Arc<AppState>>) -> Result<(), (StatusCode, St
 }
 
 /// Get index directory used by CoreDB.
-async fn get_index_dir(State(state): State<Arc<AppState>>) -> String {
-  state.coredb.get_index_dir()
+async fn get_index_dir(
+  State(state): State<Arc<AppState>>,
+  Path(index_name): Path<String>,
+) -> String {
+  state.coredb.get_index_dir(&index_name)
 }
 
 /// Ping to check if the server is up.
@@ -811,7 +824,7 @@ mod tests {
   use std::io::Write;
 
   use axum::{
-    body::Body,
+    body::{to_bytes, Body},
     http::{self, Request, StatusCode},
   };
   use chrono::Utc;
@@ -856,7 +869,7 @@ mod tests {
       get_joined_path(config_dir_path, Settings::get_default_config_file_name());
     {
       let index_dir_path_line = format!("index_dir_path = \"{}\"\n", index_dir_path);
-      let default_index_name = format!("default_index_name = \"{}\"\n", ".default");
+      let default_index_name = format!("default_index_name = \"{}\"\n", "default");
       let container_name_line = format!("container_name = \"{}\"\n", container_name);
       let use_rabbitmq_str = use_rabbitmq
         .then(|| "yes".to_string())
@@ -904,6 +917,7 @@ mod tests {
 
   async fn check_search_logs(
     app: &mut Router,
+    index_name: &str,
     config_dir_path: &str,
     search_text: &str,
     query: LogsQuery,
@@ -923,40 +937,47 @@ mod tests {
       query_end_time
     );
 
-    let uri = format!("/search_logs?{}", query_string);
+    let path = format!("/{}/search_logs?{}", index_name, query_string);
 
-    // Now call search to get the documents.
-    let response = app
-      .call(
-        Request::builder()
-          .method(http::Method::GET)
-          .uri(uri)
-          .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
-          .body(Body::from(""))
-          .unwrap(),
-      )
-      .await
+    let request = Request::builder()
+      .method(http::Method::GET)
+      .uri(path)
+      .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+      .body(Body::from(""))
       .unwrap();
 
-    assert_eq!(response.status(), StatusCode::OK);
+    let result = app.call(request).await;
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-      .await
-      .unwrap();
-    let log_messages_received: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    if let Ok(response) = result {
+      // assert_eq!(response.status(), StatusCode::OK);
+      let body = response.into_body();
+      let max_body_size = 10 * 1024 * 1024; // Example: 10MB limit
+      let bytes = to_bytes(body, max_body_size)
+        .await
+        .expect("Failed to read body");
+      let body_str = std::str::from_utf8(&bytes).expect("Body was not valid UTF-8");
+      debug!("Response content: {}", body_str);
 
-    let hits = log_messages_received["hits"]["total"]["value"]
-      .as_u64()
-      .unwrap();
+      let log_messages_received: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
 
-    assert_eq!(log_messages_expected.get_messages().len() as u64, hits);
+      let hits = log_messages_received["hits"]["total"]["value"]
+        .as_u64()
+        .unwrap();
+
+      assert_eq!(log_messages_expected.get_messages().len() as u64, hits);
+    } else if let Err(e) = result {
+      error!("Failed to make a call: {:?}", e);
+      return Err(CoreDBError::IOError(e.to_string()));
+    }
+
+    let path = format!("/{}/flush", index_name);
 
     // Flush the index.
     let response = app
       .call(
         Request::builder()
           .method(http::Method::POST)
-          .uri("/flush")
+          .uri(path)
           .body(Body::from(""))
           .unwrap(),
       )
@@ -967,7 +988,7 @@ mod tests {
     // Sleep for 2 seconds and refresh from the index directory.
     sleep(Duration::from_millis(2000)).await;
 
-    let refreshed_coredb = CoreDB::refresh(config_dir_path).await?;
+    let refreshed_coredb = CoreDB::refresh(index_name, config_dir_path).await?;
     let start_time = query.start_time.unwrap_or(0);
     let end_time = query
       .end_time
@@ -975,7 +996,7 @@ mod tests {
 
     // Handle errors from search_logs
     let log_messages_result = refreshed_coredb
-      .search_logs(search_text, "", start_time, end_time)
+      .search_logs(index_name, search_text, "", start_time, end_time)
       .await;
 
     match log_messages_result {
@@ -1021,6 +1042,7 @@ mod tests {
   // Check that metrics queries adhere to Prometheus input and output format
   async fn check_time_series(
     app: &mut Router,
+    index_name: &str,
     config_dir_path: &str,
     query: MetricsQuery,
     metric_points_expected: Vec<MetricPoint>,
@@ -1043,7 +1065,7 @@ mod tests {
       query_end_time
     );
 
-    let uri = format!("/search_metrics?{}", query_string);
+    let uri = format!("/{}/search_metrics?{}", index_name, query_string);
 
     let response = app
       .call(
@@ -1119,12 +1141,14 @@ mod tests {
       _ => panic!("Unexpected status value in response"),
     }
 
+    let path = format!("/{}/flush", index_name);
+
     // Flush the index.
     let response = app
       .call(
         Request::builder()
           .method(http::Method::POST)
-          .uri("/flush")
+          .uri(path)
           .body(Body::from(""))
           .unwrap(),
       )
@@ -1136,7 +1160,7 @@ mod tests {
     sleep(Duration::from_secs(2)).await;
 
     // Refresh CoreDB instance with the given configuration directory path.
-    let refreshed_coredb = CoreDB::refresh(config_dir_path).await?;
+    let refreshed_coredb = CoreDB::refresh(index_name, config_dir_path).await?;
 
     // Calculate the start and end time for querying metrics post-refresh.
     let start_time = query.start.unwrap_or(0);
@@ -1147,6 +1171,7 @@ mod tests {
     // Use the refreshed CoreDB instance to search metrics with updated parameters.
     let mut results = refreshed_coredb
       .search_metrics(
+        index_name,
         &query.query.unwrap_or_default(),
         "",
         0,
@@ -1177,7 +1202,8 @@ mod tests {
   async fn test_basic_main(use_rabbitmq: bool) -> Result<(), CoreDBError> {
     let config_dir = TempDir::new("config_test").unwrap();
     let config_dir_path = config_dir.path().to_str().unwrap();
-    let index_dir = TempDir::new("index_test").unwrap();
+    let index_name = "index_test";
+    let index_dir = TempDir::new(index_name).unwrap();
     let index_dir_path = index_dir.path().to_str().unwrap();
     let container_name = "infino-test-main-rs";
 
@@ -1217,7 +1243,105 @@ mod tests {
       .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    // **Part 1**: Test insertion and search of log messages
+    // **Part 1**: Test insertion and search of log messages across many indexes
+    let num_log_messages = 10;
+    for i in 0..num_log_messages {
+      let time = Utc::now().timestamp_millis() as u64;
+
+      let mut log = HashMap::new();
+      log.insert("date", json!(time));
+      log.insert("field12", json!("value1 value2"));
+      log.insert("field34", json!("value3 value4"));
+
+      let index_str = format!("{}+{}", index_name, i);
+
+      // Create a single index.
+      let response = app
+        .call(
+          Request::builder()
+            .method(http::Method::PUT)
+            .uri(&format!("/{}", index_str))
+            .body(Body::from(""))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+      assert_eq!(response.status(), StatusCode::OK);
+
+      let path = format!("/{}/append_log", index_str);
+
+      info!("Writing to path: {:?}", path);
+
+      let response = app
+        .call(
+          Request::builder()
+            .method(http::Method::POST)
+            .uri(path)
+            .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+            .body(Body::from(serde_json::to_string(&log).unwrap()))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+      assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    for i in 0..num_log_messages {
+      let mut log_messages_expected: Vec<QueryLogMessage> = Vec::new();
+
+      let time = Utc::now().timestamp_millis() as u64;
+
+      // Create the expected LogMessage.
+      let mut fields = HashMap::new();
+      fields.insert("field12".to_owned(), "value1 value2".to_owned());
+      fields.insert("field34".to_owned(), "value3 value4".to_owned());
+      let text = "value1 value2 value3 value4";
+      let message = LogMessage::new_with_fields_and_text(time, &fields, text);
+
+      log_messages_expected.push(QueryLogMessage::new_with_params(0, message));
+
+      // Sort the expected log messages in reverse chronological order.
+      log_messages_expected.sort();
+
+      let search_query = &format!("value1 field34{}value4", FIELD_DELIMITER);
+
+      let mut query_object = QueryDSLObject::new();
+      query_object.set_messages(log_messages_expected);
+
+      let query = LogsQuery {
+        start_time: None,
+        end_time: None,
+        text: search_query.to_owned(),
+      };
+
+      let index_str = format!("{}+{}", index_name, i);
+
+      check_search_logs(
+        &mut app,
+        &index_str,
+        config_dir_path,
+        search_query,
+        query,
+        query_object,
+      )
+      .await?;
+    }
+
+    // **Part 2**: Test insertion and search of log messages in single index
+
+    // Create a single index.
+    let response = app
+      .call(
+        Request::builder()
+          .method(http::Method::PUT)
+          .uri(&format!("/{}", index_name))
+          .body(Body::from(""))
+          .unwrap(),
+      )
+      .await
+      .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
     let num_log_messages = 100;
     let mut log_messages_expected: Vec<QueryLogMessage> = Vec::new();
     for i in 0..num_log_messages {
@@ -1228,11 +1352,13 @@ mod tests {
       log.insert("field12", json!("value1 value2"));
       log.insert("field34", json!("value3 value4"));
 
+      let path = format!("/{}/append_log", index_name);
+
       let response = app
         .call(
           Request::builder()
             .method(http::Method::POST)
-            .uri("/append_log")
+            .uri(path)
             .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
             .body(Body::from(serde_json::to_string(&log).unwrap()))
             .unwrap(),
@@ -1264,7 +1390,15 @@ mod tests {
       end_time: None,
       text: search_query.to_owned(),
     };
-    check_search_logs(&mut app, config_dir_path, search_query, query, query_object).await?;
+    check_search_logs(
+      &mut app,
+      index_name,
+      config_dir_path,
+      search_query,
+      query,
+      query_object,
+    )
+    .await?;
 
     // End time in this query is too old - this should yield 0 results.
     let query_too_old = LogsQuery {
@@ -1274,6 +1408,7 @@ mod tests {
     };
     check_search_logs(
       &mut app,
+      index_name,
       config_dir_path,
       search_query,
       query_too_old,
@@ -1281,7 +1416,7 @@ mod tests {
     )
     .await?;
 
-    // **Part 2**: Test insertion and search of time series metric points.
+    // **Part 3**: Test insertion and search of time series metric points.
     let num_metric_points = 100;
     let mut metric_points_expected = Vec::new();
     let name_for_metric_name_label = "__name__";
@@ -1295,12 +1430,14 @@ mod tests {
       let json_str = format!("{{\"date\": {}, \"{}\":{}}}", time, metric_name, value);
       metric_points_expected.push(metric_point);
 
+      let path = format!("/{}/append_metric", index_name);
+
       // Insert the metric.
       let response = app
         .call(
           Request::builder()
             .method(http::Method::POST)
-            .uri("/append_metric")
+            .uri(path)
             .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
             .body(Body::from(json_str))
             .unwrap(),
@@ -1321,7 +1458,14 @@ mod tests {
       start: None,
       end: None,
     };
-    check_time_series(&mut app, config_dir_path, query, metric_points_expected).await?;
+    check_time_series(
+      &mut app,
+      index_name,
+      config_dir_path,
+      query,
+      metric_points_expected,
+    )
+    .await?;
 
     // End time in this query is too old - this should yield 0 results.
     // Test legacy Infino syntax here
@@ -1333,14 +1477,16 @@ mod tests {
       start: Some(1),
       end: Some(10000),
     };
-    check_time_series(&mut app, config_dir_path, query, Vec::new()).await?;
+    check_time_series(&mut app, index_name, config_dir_path, query, Vec::new()).await?;
+
+    let path = format!("/{}/flush", index_name);
 
     // Check whether the /flush works.
     let response = app
       .call(
         Request::builder()
           .method(http::Method::POST)
-          .uri("/flush")
+          .uri(path)
           .body(Body::from(""))
           .unwrap(),
       )
@@ -1358,7 +1504,8 @@ mod tests {
   async fn test_body_limit() -> Result<(), CoreDBError> {
     let config_dir = TempDir::new("config_test").unwrap();
     let config_dir_path = config_dir.path().to_str().unwrap();
-    let index_dir = TempDir::new("index_test").unwrap();
+    let index_name = "index_test";
+    let index_dir = TempDir::new(index_name).unwrap();
     let index_dir_path = index_dir.path().to_str().unwrap();
     let container_name = "infino-test-main-rs";
 
@@ -1385,12 +1532,14 @@ mod tests {
     let body_len = body.len();
     assert!(body_len > 2 * 1024 * 1024 && body_len < 5 * 1024 * 1024);
 
+    let path = format!("/{}/append_log", index_name);
+
     // Send a large request.
     let response = app
       .call(
         Request::builder()
           .method(http::Method::POST)
-          .uri("/append_log")
+          .uri(path)
           .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
           .body(Body::from(body))
           .unwrap(),
@@ -1412,7 +1561,8 @@ mod tests {
   async fn test_create_delete_index(use_rabbitmq: bool) {
     let config_dir = TempDir::new("config_test").unwrap();
     let config_dir_path = config_dir.path().to_str().unwrap();
-    let index_dir = TempDir::new("index_test").unwrap();
+    let index_name = "index_test";
+    let index_dir = TempDir::new(index_name).unwrap();
     let index_dir_path = index_dir.path().to_str().unwrap();
     let container_name = "infino-test-main-rs";
     let storage = Storage::new(&StorageType::Local)
@@ -1430,7 +1580,6 @@ mod tests {
     let (mut app, _, _) = app(config_dir_path, "rabbitmq", "3").await;
 
     // Create an index.
-    let index_name = "test_index";
     let response = app
       .call(
         Request::builder()


### PR DESCRIPTION
Support for multiple indexes. THIS MODIFIES THE PUBLIC API.

## What does this PR do?
- Exposes the internal multi-index support via the API
- Modifies the examples, client, etc. accordingly.

## How does this PR work? (optional)
- Passes an index name from the API to the CoreDB layer
- CoreDB layer grabs index object from the index map
- API request is then made on the specified index
- Commit thread cycles through all indexes to commit but manual commit (i.e. flush) is only on a single index.

## Refer to a related PR or issue link
[- (Related PR or issue)](https://github.com/infinohq/infino/issues/115)

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
