### PR TITLE
Create an index before appending documents in rust apache logs example

### DIFF
--- a/coredb/src/index_manager/index.rs
+++ b/coredb/src/index_manager/index.rs
@@ -128,6 +128,7 @@ impl Index {
     let storage = Storage::new(storage_type).await?;
     if !storage.check_path_exists(index_dir_path).await {
       // Index directory does not exist - create it.
+      info!("Creating index directory {}", index_dir_path);
       storage.create_dir(index_dir_path)?;
     }
 
@@ -135,6 +136,7 @@ impl Index {
     let wal_storage = Storage::new(&StorageType::Local).await?;
     if !wal_storage.check_path_exists(wal_dir_path).await {
       // WAL directory does not exist - create it.
+      info!("Creating WAL directory {}", wal_dir_path);
       wal_storage.create_dir(wal_dir_path)?;
     }
 

--- a/examples/rust-apache-logs/src/main.rs
+++ b/examples/rust-apache-logs/src/main.rs
@@ -127,6 +127,28 @@ fn get_args() -> (String, i64, String, bool) {
   (file.clone(), *count, infino_url.clone(), *coredb_only)
 }
 
+async fn create_index(client: &Client, create_index_url: &str) {
+  let response = client
+    .put(create_index_url)
+    .header("Content-Type", "application/json")
+    .body(Body::from(serde_json::to_string("").unwrap()))
+    .send()
+    .await;
+  let status = response.as_ref().unwrap().status();
+  assert_eq!(status, 200);
+}
+
+async fn delete_index(client: &Client, delete_index_url: &str) {
+  let response = client
+    .delete(delete_index_url)
+    .header("Content-Type", "application/json")
+    .body(Body::from(serde_json::to_string("").unwrap()))
+    .send()
+    .await;
+  let status = response.as_ref().unwrap().status();
+  assert_eq!(status, 200);
+}
+
 async fn index_logs_batch(client: &Client, append_url: &str, logs_batch: &Vec<ApacheLogEntry>) {
   loop {
     let response = client
@@ -160,16 +182,20 @@ async fn index(
   let mut logs_batch = Vec::new();
   let now = Instant::now();
   let append_url = &format!("{}/max_docs/append_log", infino_url);
+  let create_delete_index_url = &format!("{}/max_docs", infino_url);
   let client = reqwest::Client::new();
-
-  // User only when coredb_only is set to true.
   let config_dir_path = "../../config";
   let coredb = CoreDB::new(config_dir_path).await.unwrap();
   let index_name = "max_docs";
 
-  let create_result = coredb.create_index(index_name).await;
-  if create_result.is_err() {
-    println!("Received create index error from CoreDB",);
+  // Create index.
+  if coredb_only {
+    let create_result = coredb.create_index(index_name).await;
+    if create_result.is_err() {
+      println!("Received create index error from CoreDB",);
+    }
+  } else {
+    create_index(&client, create_delete_index_url).await;
   }
 
   let file = File::open(file_path).await.unwrap();
@@ -236,9 +262,14 @@ async fn index(
     elapsed, throughout
   );
 
-  let delete_result = coredb.delete_index(index_name).await;
-  if delete_result.is_err() {
-    println!("Received delete index error from CoreDB",);
+  // Delete index.
+  if coredb_only {
+    let delete_result = coredb.delete_index(index_name).await;
+    if delete_result.is_err() {
+      println!("Received delete index error from CoreDB",);
+    }
+  } else {
+    //delete_index(&client, create_delete_index_url).await;
   }
 
   Ok(())

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -180,7 +180,7 @@ async fn app(
     .route("/:index_name/append_log", post(append_log))
     .route("/:index_name/append_metric", post(append_metric))
     .route("/flush", post(flush))
-    // PUT methods
+    // PUT and DELETE methods
     .route("/:index_name", put(create_index))
     .route("/:index_name", delete(delete_index))
     // ---
@@ -784,7 +784,7 @@ async fn create_index(
   state: State<Arc<AppState>>,
   Path(index_name): Path<String>,
 ) -> Result<(), (StatusCode, String)> {
-  debug!("Creating index {}", index_name);
+  info!("Creating index {}", index_name);
 
   let result = state.coredb.create_index(&index_name).await;
 
@@ -802,7 +802,7 @@ async fn delete_index(
   State(state): State<Arc<AppState>>,
   Path(index_name): Path<String>,
 ) -> Result<(), (StatusCode, String)> {
-  debug!("Deleting index {}", index_name);
+  info!("Deleting index {}", index_name);
 
   let result = state.coredb.delete_index(&index_name).await;
   if result.is_err() {


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Create an index before appending documents in rust apache logs example
