### PR TITLE
Clean shutdown of various background threads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ docker-push: docker-check
 # `make example-apache-logs file=../datasets/apache-tiny.log count=100000`
 example-apache-logs:
 	cd examples/rust-apache-logs && \
-	cargo run $(release) --bin rust-apache-logs -- --file $(file) --count $(count)
+	cargo run --bin rust-apache-logs -- --file $(file) --count $(count)
 
 # Start Infino server for memory profiling using dhat.
 run-profile-server:

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ docker-push: docker-check
 # `make example-apache-logs file=../datasets/apache-tiny.log count=100000`
 example-apache-logs:
 	cd examples/rust-apache-logs && \
-	cargo run --bin rust-apache-logs -- --file $(file) --count $(count)
+	cargo run $(release) --bin rust-apache-logs -- --file $(file) --count $(count)
 
 # Start Infino server for memory profiling using dhat.
 run-profile-server:

--- a/server/src/background_threads.rs
+++ b/server/src/background_threads.rs
@@ -90,7 +90,7 @@ fn check_and_start_retention_thread(
 
 /// Periodically commits CoreDB to disk (typically called in a thread so that CoreDB
 /// can be asyncronously committed), and triggers retention policy every hour
-pub async fn commit_in_loop(state: Arc<AppState>) {
+pub async fn check_and_start_background_threads(state: Arc<AppState>) {
   let mut last_trigger_policy_time = Utc::now().timestamp_millis() as u64;
   let mut flush_wal_handle: Option<JoinHandle<()>> = None;
   let mut commit_handle: Option<JoinHandle<()>> = None;
@@ -101,7 +101,7 @@ pub async fn commit_in_loop(state: Arc<AppState>) {
 
   loop {
     // Start flush log thread - if one isn't running already.
-    check_and_start_flush_wal_thread(state.clone(), &mut flush_wal_handle);
+    /*check_and_start_flush_wal_thread(state.clone(), &mut flush_wal_handle);
 
     // Check if we need to shut down (typically triggered by the user by sending Ctrl-C on Infino server).
     // We can check for this anywhere in the loop, but we check just before commit to avoid extra work
@@ -127,10 +127,10 @@ pub async fn commit_in_loop(state: Arc<AppState>) {
       .expect("Could not wait for the background threads to finish");
 
       break;
-    }
+    }*/
 
     // Start retention thread - if one isn't running already.
-    let current_time = Utc::now().timestamp_millis() as u64;
+    /*let current_time = Utc::now().timestamp_millis() as u64;
     if current_time - last_trigger_policy_time > policy_interval_ms {
       let new_retention_thread_started =
         check_and_start_retention_thread(state.clone(), &mut retention_handle);
@@ -138,7 +138,7 @@ pub async fn commit_in_loop(state: Arc<AppState>) {
         // Update last_trigger_policy_time only if a new retention thread was started.
         last_trigger_policy_time = current_time;
       }
-    }
+    }*/
 
     // Sleep for some time before committing again.
     sleep(Duration::from_millis(1000)).await;

--- a/server/src/background_threads.rs
+++ b/server/src/background_threads.rs
@@ -88,8 +88,12 @@ fn check_and_start_retention_thread(
   false
 }
 
-/// Periodically commits CoreDB to disk (typically called in a thread so that CoreDB
-/// can be asyncronously committed), and triggers retention policy every hour
+/// Periodically start background threads such flushing WAL, commit and execute retention policy.
+/// The threads for each of these tasks are started only if there isn't a currently running thread
+/// for the same task.
+///
+/// Checks crate::IS_SHUTDOWN to know whether to shut down, and in that case waits for the currently
+/// executing threads to finish and then returns.
 pub async fn check_and_start_background_threads(state: Arc<AppState>) {
   let mut last_trigger_policy_time = Utc::now().timestamp_millis() as u64;
   let mut flush_wal_handle: Option<JoinHandle<()>> = None;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -755,6 +755,7 @@ async fn search_metrics(
 
 /// Flush the index to disk.
 async fn flush(State(state): State<Arc<AppState>>) -> Result<(), (StatusCode, String)> {
+  let _ = state.coredb.flush_wal().await;
   let result = state.coredb.commit(true).await;
 
   match result {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -237,12 +237,12 @@ async fn run_server() {
       .expect("Could not stop rabbitmq container");
   }
 
-  // Set the flag to indicate the commit thread to shutdown, and wait for it to finish.
+  // Set the flag to indicate the background threads to shutdown, and wait for them to finish.
   IS_SHUTDOWN.store(true);
-  info!("Shutting down commit thread and waiting for it to finish...");
+  info!("Shutting down background threads and waiting for it to finish...");
   background_threads_handle
     .await
-    .expect("Error while completing the commit thread");
+    .expect("Error while shutting down the background threads");
 
   info!("Completed Infino server shutdown");
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -985,8 +985,8 @@ mod tests {
       .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    // Sleep for 2 seconds and refresh from the index directory.
-    sleep(Duration::from_millis(2000)).await;
+    // Sleep for 5 seconds and refresh from the index directory.
+    sleep(Duration::from_millis(5000)).await;
 
     let refreshed_coredb = CoreDB::refresh(index_name, config_dir_path).await?;
     let start_time = query.start_time.unwrap_or(0);
@@ -1154,8 +1154,8 @@ mod tests {
       .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    // Sleep for 2 seconds to simulate delay or wait for a condition.
-    sleep(Duration::from_secs(2)).await;
+    // Sleep for 5 seconds to simulate delay or wait for a condition.
+    sleep(Duration::from_secs(5)).await;
 
     // Refresh CoreDB instance with the given configuration directory path.
     let refreshed_coredb = CoreDB::refresh(index_name, config_dir_path).await?;


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
Refactor spawning and shutting down of background threads such as flush wal, commit and retention policy thread. Also increases stability of the server during shutdown.
