### PR TITLE
Updates benches to support infino-opensearch via the REST plugin

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -50,12 +50,33 @@ $ cd benches
 $ cargo run -r
 ```
 
-## Run only Infino
+## Run only specific benchmarks
 
 Sometimes, you may want to run only Infino to see its resource usage, or profile the code. In this scenario, to run only Infino, use:
+Sometimes, you may want to run only specific benchmarks, for example only Infino via REST API and Elastic, or only Infino via REST API. To do so you can use,
 ```
-$ cargo run -r -- --stop-after-infino
+$ cargo run -r -- --infino-rest --elastic
 ```
+
+## Run with different datasets
+To use a different log file as input data use `--input-file` option as shown below.
+```
+$ cargo run -r -- --infino-rest --input-file=data/Apache_2G.log
+```
+
+## All run time option
+Below are the options to run the benchmarks.
+```
+--infino
+--infino-rest
+--infino-os
+--elastic
+--clickhouse
+--infino-metrics
+--prometheus
+--input-file=<path to input file>
+```
+
 
 ## Results (Apache log - small):
 

--- a/benches/config/default.toml
+++ b/benches/config/default.toml
@@ -1,13 +1,40 @@
 [coredb]
-index_dir_path = "index"
+### Storage configuration.
+storage_type = "local"                # can be "local", "aws", "gcp" or "azure"
+cloud_storage_bucket_name = "dev-infino-data"   # only relevant if storage type is "aws", "gcp", or "azure"
+index_dir_path = "data"
+# "cloud_storage_region" can be used to set a region for the cloud provider
+
+### Index configuration.
 default_index_name = "default"
-num_log_messages_threshold = 100000
-num_metric_points_threshold = 100000
+
+# Maximum number of log messages or metric points in a segment during appends. A new segment
+# will be created after these thresholds are reached.
+log_messages_threshold = 100000       # 100K
+metric_points_threshold = 1000000     # 1M
+
+# Memory budget for searching segments. Expect the actual memory used to be higher 
+# (but proportional) to this number.
+search_memory_budget_megabytes = 1024
+
+# Maximum number of uncommitted segments. The appends will return 413 when the commits
+# fall behind 
+uncommitted_segments_threshold = 10
+
+# Number of days to retain older older logs and metrics.
 retention_days = 30
 
 [server]
 port = 3000
-commit_interval_in_seconds = 30
+host = "0.0.0.0"
+timestamp_key = "date"
+labels_key = "labels"
+use_rabbitmq = "no"             # specifies whether to write incoming messages to rabbitmq
 
+
+# In case the server section specifies to use rabbitmq (use_rabbitmq = yes),
+# configuration for rabbitmq needs to be specified. Sample configuration below.
 [rabbitmq]
 container_name = "infino-queue"
+stream_port = 5552
+listen_port = 5672

--- a/benches/src/logs/infino.rs
+++ b/benches/src/logs/infino.rs
@@ -54,7 +54,7 @@ impl InfinoEngine {
         }
       }
 
-      self.coredb.commit().await.expect("Could not commit coredb");
+      self.coredb.commit(false).await.expect("Could not commit coredb");
     }
     let elapsed = now.elapsed().as_micros();
     println!(
@@ -79,7 +79,7 @@ impl InfinoEngine {
           "Infino time required for searching logs {} is : {} microseconds. Num of results {}",
           query,
           elapsed,
-          result.len()
+          result.get_messages().len()
         );
         elapsed
       }

--- a/benches/src/logs/infino_os_rest.rs
+++ b/benches/src/logs/infino_os_rest.rs
@@ -1,0 +1,147 @@
+// This code is licensed under Apache License 2.0
+// https://www.apache.org/licenses/LICENSE-2.0
+
+use std::{time::Instant};
+
+use chrono::Utc;
+use reqwest::Body;
+use serde_json::json;
+
+use crate::utils::io;
+
+pub struct InfinoOSApiClient {
+  // No configuration needed-
+}
+
+impl InfinoOSApiClient {
+  pub fn new() -> InfinoOSApiClient {
+    InfinoOSApiClient {}
+  }
+
+  /// Indexes input data and returns the time required for insertion as microseconds.
+  pub async fn index_lines(&self, input_data_path: &str, max_docs: i32) -> u128 {
+    let mut num_docs = 0;
+
+    let num_docs_per_batch = 100;
+    let mut num_docs_in_this_batch = 0;
+    let mut logs_batch = Vec::new();
+    let now = Instant::now();
+
+    if let Ok(lines) = io::read_lines(input_data_path) {
+      let client = reqwest::Client::new();
+      for line in lines {
+        num_docs += 1;
+        num_docs_in_this_batch += 1;
+
+        // If max_docs is less than 0, we index all the documents.
+        // Otherwise, do not indexing more than max_docs documents.
+        if max_docs > 0 && num_docs > max_docs {
+          println!(
+            "Already indexed {} documents. Not indexing anymore.",
+            max_docs
+          );
+          break;
+        }
+        if let Ok(message) = line {
+          logs_batch.push(json!(
+            {"index": {"_id": num_docs}}
+          ));
+          logs_batch.push(json!({ 
+            "_id": num_docs,
+            "date": Utc::now().timestamp_millis() as u64,
+            "message": message,
+          }));
+          if num_docs_in_this_batch == num_docs_per_batch {
+            // Join all elements in logs_batch delimitted by \n 
+            let body_str = logs_batch.iter()
+                              .map(|v| v.to_string())
+                              .collect::<Vec<_>>()
+                              .join("\n");
+
+            // Prepend and append a newline to the body string
+            let mut body_str_newline = String::new();
+            body_str_newline.push('\n');
+            body_str_newline.push_str(&body_str);
+            body_str_newline.push('\n');
+
+            let _ = client
+              .post("http://localhost:9200/infino/_bulk")
+              .header("Content-Type", "application/json")
+              .body(Body::from(body_str_newline))
+              .send()
+              .await;
+            logs_batch.clear();
+            num_docs_in_this_batch = 0;
+          }
+        }
+      }
+    }
+
+    let elapsed = now.elapsed().as_micros();
+    println!(
+      "Infino OS REST API - time required for log insertions: {} microseconds",
+      elapsed
+    );
+    elapsed
+  }
+
+  /// Searches the given term and returns the time required in microseconds
+  pub async fn search_logs(&self, text: &str, range_start_time: u64, range_end_time: u64) -> u128 {
+    let query_url = &format!(
+      "http://localhost:9200/infino/perfindex/logs?text={}&startTime={}&endTime={}",
+      text, range_start_time, range_end_time
+    );
+
+    let now = Instant::now();
+    let response = reqwest::get(query_url).await;
+    let elapsed = now.elapsed().as_micros();
+    println!(
+      "Infino OS REST API - time required for logs search {} is : {} microseconds",
+      text, elapsed
+    );
+
+    //println!("Response {:?}", response);
+    match response {
+      Ok(res) => {
+        #[allow(unused)]
+        let text = res.text().await.unwrap();
+        //println!("Result {}", text);
+      }
+      Err(err) => {
+        println!("Error while fetching from Infino: {}", err);
+      }
+    }
+    elapsed
+  }
+
+  /// Runs multiple queries and returns the sum of time needed to run them in microseconds.
+  pub async fn search_multiple_queries(&self, queries: &[&str]) -> u128 {
+    let mut time = 0;
+    for query in queries {
+      time += self.search_logs(query, 0, u64::MAX).await;
+    }
+    time
+  }
+
+/* 
+ * flush is not implemented in Infino OS.
+ * We'll un-comment this and update it with the right API end point
+ * when flush is implemented.
+ * 
+  #[allow(unused)]
+  pub async fn flush(&self) {
+    let client = reqwest::Client::new();
+
+    let _ = client
+      .post("http://localhost:2999/flush")
+      .body("")
+      .send()
+      .await;
+  }
+ */
+
+  #[allow(unused)]
+  pub fn get_index_dir_path(&self) -> &str {
+    "../index"
+  }
+}

--- a/benches/src/logs/infino_os_rest.rs
+++ b/benches/src/logs/infino_os_rest.rs
@@ -88,7 +88,7 @@ impl InfinoOSApiClient {
   /// Searches the given term and returns the time required in microseconds
   pub async fn search_logs(&self, text: &str, range_start_time: u64, range_end_time: u64) -> u128 {
     let query_url = &format!(
-      "http://localhost:9200/infino/perfindex/logs?text={}&startTime={}&endTime={}",
+      "http://localhost:9200/infino/perfindex/logs/_search?text={}&startTime={}&endTime={}",
       text, range_start_time, range_end_time
     );
 

--- a/benches/src/logs/mod.rs
+++ b/benches/src/logs/mod.rs
@@ -5,3 +5,4 @@ pub mod clickhouse;
 pub mod es;
 pub mod infino;
 pub mod infino_rest;
+pub mod infino_os_rest;

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -49,239 +49,344 @@ static ELASTICSEARCH_SEARCH_QUERIES: &[&str] = &[
 #[structopt(name = "basic")]
 struct Opt {
   #[structopt(short, long)]
-  stop_after_infino: bool,
+  infino: bool,
 
   #[structopt(short, long)]
-  stop_after_infino_os: bool,
+  infino_rest: bool,
+
+  #[structopt(short, long)]
+  infino_os: bool,
+
+  #[structopt(short, long)]
+  elastic: bool,
+
+  #[structopt(short, long)]
+  clickhouse: bool,
+
+  #[structopt(short, long)]
+  infino_metrics: bool,
+
+  #[structopt(short, long)]
+  prometheus: bool,
+
+  #[structopt(short, long, default_value = "data/Apache.log")]
+  input_file: String,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
   let opt = Opt::from_args();
-  println!("{:#?}", opt.stop_after_infino);
-  println!("{:#?}", opt.stop_after_infino_os);
+
+  let run_all = !opt.infino &&
+                !opt.infino_rest &&
+                !opt.infino_os &&
+                !opt.elastic &&
+                !opt.clickhouse &&
+                !opt.infino_metrics &&
+                !opt.prometheus;
+
+
+  // Some string variables to progressively collect the test results and print it at the end
+  let mut idx_size_title_str = String::from("| dataset |");
+  let mut idx_size_dashes_str = String::from("| ----- |");
+  let mut idx_size_values_str = String::from(format!("| {} |", &opt.input_file));
+
+  let mut idx_lat_title_str = String::from("| dataset |");
+  let mut idx_lat_dashes_str = String::from("| ----- |");
+  let mut idx_lat_values_str = String::from(format!("| {} |", &opt.input_file));
+
+  let mut log_search_lat_title_str = String::from("| dataset |");
+  let mut log_search_lat_dashes_str = String::from("| ----- |");
+  let mut log_search_lat_values_str = String::from(format!("| {} |", &opt.input_file));
+
+  let mut metrics_search_lat_title_str = String::from("| Metric Points |");
+  let mut metrics_search_lat_dashes_str = String::from("| ----- |");
+  let mut metrics_search_lat_values_str = String::from("| Search Latency |");
 
   // Path to the input data to index from. Points to a log file - where each line is indexed
   // as a separate document in the elasticsearch index and the infino index.
-  let input_data_path = "data/Apache.log";
-  let cell_input_data_size = std::fs::metadata(input_data_path)
+  let cell_input_data_size = std::fs::metadata(&opt.input_file)
     .map(|metadata| metadata.len())
     .expect("Could not get the input data size");
 
   // Maximum number of documents to index. Set this to -1 to index all the documents.
   let max_docs = -1;
- 
-  // INFINO START
-  println!("\n\n***Now running Infino via CoreDB library***");
 
-  // Index the data using infino and find the output size.
-  let curr_dir = std::env::current_dir().unwrap();
+  if run_all || opt.infino {
+    // INFINO START
+    println!("\n\n***Now running Infino via CoreDB library***");
 
-  let config_path = format!("{}/{}", &curr_dir.to_str().unwrap(), "config");
+    // Index the data using infino and find the output size.
+    let curr_dir = std::env::current_dir().unwrap();
 
-  let mut infino = InfinoEngine::new(&config_path).await;
-  let cell_infino_index_time = infino.index_lines(input_data_path, max_docs).await;
-  let cell_infino_index_size = get_directory_size(infino.get_index_dir_path());
-  println!("Infino index size = {} bytes", cell_infino_index_size);
+    let config_path = format!("{}/{}", &curr_dir.to_str().unwrap(), "config");
 
-  // Perform search on infino index
-  let cell_infino_search_time = infino.search_multiple_queries(INFINO_SEARCH_QUERIES).await;
+    let mut infino = InfinoEngine::new(&config_path).await;
+    let cell_infino_index_time = infino.index_lines(&opt.input_file, max_docs).await;
+    let cell_infino_index_size = get_directory_size(infino.get_index_dir_path());
+    println!("Infino index size = {} bytes", cell_infino_index_size);
 
-  let _ = fs::remove_dir_all(format! {"{}/index", &curr_dir.to_str().unwrap()});
+    // Perform search on infino index
+    let cell_infino_search_time = infino.search_multiple_queries(INFINO_SEARCH_QUERIES).await;
 
-  // INFINO END
+    let _ = fs::remove_dir_all(format! {"{}/index", &curr_dir.to_str().unwrap()});
 
-  if opt.stop_after_infino {
-    println!("stop_after_infino is set. Stopping now...");
-    return Ok(());
+    idx_size_title_str += " Infino |";
+    idx_size_dashes_str += " ----- |";
+    idx_size_values_str += &format!(" {} |", cell_infino_index_size);
+
+    idx_lat_title_str += " Infino |";
+    idx_lat_dashes_str += " ----- |";
+    idx_lat_values_str += &format!(" {} |", cell_infino_index_time);
+
+    log_search_lat_title_str += " Infino |";
+    log_search_lat_dashes_str += " ----- |";
+    log_search_lat_values_str += &format!(" {} |",
+                  cell_infino_search_time / INFINO_SEARCH_QUERIES.len() as u128);
+
+    // INFINO END
   }
 
-  // INFINO REST START
-  println!("\n\n***Now running Infino via the REST API client***");
+  if run_all || opt.infino_rest {
+    // INFINO REST START
+    println!("\n\n***Now running Infino via the REST API client***");
 
-  // Index the data using infino and find the output size.
-  let infino_rest = InfinoApiClient::new();
-  let cell_infino_rest_index_time = infino_rest.index_lines(input_data_path, max_docs).await;
+    // Index the data using infino and find the output size.
+    let infino_rest = InfinoApiClient::new();
+    let cell_infino_rest_index_time = infino_rest.index_lines(&opt.input_file, max_docs).await;
 
-  // TODO: The flush does not flush to disk reliably - anf it make take more time before the index is updated on disk.
-  // Figure out how to flush reliably and the code below can be uncommented.
-  // ---
-  // Flush the index to disk - sleep for a second to let the OS complete flushing.
-  //let _ = infino_rest.flush();
-  //thread::sleep(std::time::Duration::from_millis(1000));
+    // TODO: The flush does not flush to disk reliably - anf it make take more time before the index is updated on disk.
+    // Figure out how to flush reliably and the code below can be uncommented.
+    // ---
+    // Flush the index to disk - sleep for a second to let the OS complete flushing.
+    //let _ = infino_rest.flush();
+    //thread::sleep(std::time::Duration::from_millis(1000));
 
-  //let cell_infino_rest_index_size = get_directory_size(infino_rest.get_index_dir_path());
-  //println!(
-  //  "Infino via API index size = {} bytes",
-  //  cell_infino_rest_index_size
-  //);
+    //let cell_infino_rest_index_size = get_directory_size(infino_rest.get_index_dir_path());
+    //println!(
+    //  "Infino via API index size = {} bytes",
+    //  cell_infino_rest_index_size
+    //);
 
-  // Perform search on infino index
-  let cell_infino_rest_search_time = infino_rest
-    .search_multiple_queries(INFINO_SEARCH_QUERIES)
-    .await;
+    // Perform search on infino index
+    let cell_infino_rest_search_time = infino_rest
+      .search_multiple_queries(INFINO_SEARCH_QUERIES)
+      .await;
 
-  // INFINO REST END
+    idx_size_title_str += " Infino-REST |";
+    idx_size_dashes_str += " ----- |";
+    idx_size_values_str += " Not available via API |";
 
-  // INFINO OS REST START
-  println!("\n\n***Now running Infino OpenSearch via the REST API client***");
+    idx_lat_title_str += " Infino-REST |";
+    idx_lat_dashes_str += " ----- |";
+    idx_lat_values_str += &format!(" {} |", cell_infino_rest_index_time);
 
-  // Index the data using infino and find the output size.
-  let infino_os_rest = InfinoOSApiClient::new();
-  let cell_infino_os_rest_index_time = infino_os_rest.index_lines(input_data_path, max_docs).await;
+    log_search_lat_title_str += " Infino-REST |";
+    log_search_lat_dashes_str += " ----- |";
+    log_search_lat_values_str += &format!(" {} |",
+                  cell_infino_rest_search_time / INFINO_SEARCH_QUERIES.len() as u128);
+    // INFINO REST END
+    }
 
-  // Perform search on infino index
-  let cell_infino_os_rest_search_time = 0;
-  let cell_infino_os_rest_search_time = infino_os_rest
-    .search_multiple_queries(INFINO_SEARCH_QUERIES)
-    .await;
+  if run_all || opt.infino_os {
+    // INFINO OS REST START
+    println!("\n\n***Now running Infino OpenSearch via the REST API client***");
 
-  // INFINO OS REST END
-  if opt.stop_after_infino_os {
-    println!("stop_after_infino_os is set. Stopping now...");
-    return Ok(());
+    // Index the data using infino and find the output size.
+    let infino_os_rest = InfinoOSApiClient::new();
+    let cell_infino_os_rest_index_time = infino_os_rest.index_lines(&opt.input_file, max_docs).await;
+
+    // Perform search on infino index
+    let cell_infino_os_rest_search_time = infino_os_rest
+      .search_multiple_queries(INFINO_SEARCH_QUERIES)
+      .await;
+
+    idx_size_title_str += " Infino-OS-REST |";
+    idx_size_dashes_str += " ----- |";
+    idx_size_values_str += " Not available via API |";
+
+    idx_lat_title_str += " Infino-OS-REST |";
+    idx_lat_dashes_str += " ----- |";
+    idx_lat_values_str += &format!(" {} |", cell_infino_os_rest_index_time);
+
+    log_search_lat_title_str += " Infino-OS-REST |";
+    log_search_lat_dashes_str += " ----- |";
+    log_search_lat_values_str += &format!(" {} |",
+                  cell_infino_os_rest_search_time / INFINO_SEARCH_QUERIES.len() as u128);
+    // INFINO OS REST END
   }
 
-  // CLICKHOUSE START
-  println!("\n\n***Now running Clickhouse***");
+  if run_all || opt.elastic {
+    // ELASTICSEARCH START
+    println!("\n\n***Now running Elasticsearch***");
 
-  let mut clickhouse = ClickhouseEngine::new().await;
-  let cell_clickhouse_index_time = clickhouse.index_lines(input_data_path, max_docs).await;
+    // Index the data using elasticsearch and find the output size.
+    let es = ElasticsearchEngine::new().await;
+    let cell_es_index_time = es.index_lines(&opt.input_file, max_docs).await;
 
-  // The index is not necessarily immediately written by clickhouse, so sleep for some time
-  thread::sleep(std::time::Duration::from_millis(5000));
-  let cell_clickhouse_index_size = get_directory_size(clickhouse.get_index_dir_path());
-  println!(
-    "Clickhouse index size = {} bytes",
-    cell_clickhouse_index_size
-  );
+    // Force merge the index so that the index size is optimized.
+    es.forcemerge().await;
 
-  // Perform search on clickhouse index
-  let cell_clickhouse_search_time = clickhouse
-    .search_multiple_queries(CLICKHOUSE_SEARCH_QUERIES)
-    .await;
+    let cell_es_index_size = es.get_index_size().await;
 
-  // CLICKHOUSE END
+    // Perform search on elasticsearch index
+    let cell_es_search_time = es
+      .search_multiple_queries(ELASTICSEARCH_SEARCH_QUERIES)
+      .await;
 
-  // ELASTICSEARCH START
-  println!("\n\n***Now running Elasticsearch***");
+    let elasticsearch_index_size = if cell_es_index_size == 0 {
+      "<figure out from cat response>".to_owned()
+    } else {
+      cell_es_index_size.to_string()
+    };
 
-  // Index the data using elasticsearch and find the output size.
-  let es = ElasticsearchEngine::new().await;
-  let cell_es_index_time = es.index_lines(input_data_path, max_docs).await;
+    idx_size_title_str += " Elasticsearch |";
+    idx_size_dashes_str += " ----- |";
+    idx_size_values_str += &format!(" {} |", elasticsearch_index_size);
 
-  // Force merge the index so that the index size is optimized.
-  es.forcemerge().await;
+    idx_lat_title_str += " Elasticsearch |";
+    idx_lat_dashes_str += " ----- |";
+    idx_lat_values_str += &format!(" {} |", cell_es_index_time);
 
-  let cell_es_index_size = es.get_index_size().await;
+    log_search_lat_title_str += " Elasticsearch |";
+    log_search_lat_dashes_str += " ----- |";
+    log_search_lat_values_str += &format!(" {} |",
+                  cell_es_search_time / ELASTICSEARCH_SEARCH_QUERIES.len() as u128);  
 
-  // Perform search on elasticsearch index
-  let cell_es_search_time = es
-    .search_multiple_queries(ELASTICSEARCH_SEARCH_QUERIES)
-    .await;
+    // ELASTICSEARCH END
+  }
 
-  // ELASTICSEARCH END
+  if run_all || opt.clickhouse {
+    // CLICKHOUSE START
+    println!("\n\n***Now running Clickhouse***");
+
+    let mut clickhouse = ClickhouseEngine::new().await;
+    let cell_clickhouse_index_time = clickhouse.index_lines(&opt.input_file, max_docs).await;
+
+    // The index is not necessarily immediately written by clickhouse, so sleep for some time
+    thread::sleep(std::time::Duration::from_millis(5000));
+    let cell_clickhouse_index_size = get_directory_size(clickhouse.get_index_dir_path());
+    println!(
+      "Clickhouse index size = {} bytes",
+      cell_clickhouse_index_size
+    );
+
+    // Perform search on clickhouse index
+    let cell_clickhouse_search_time = clickhouse
+      .search_multiple_queries(CLICKHOUSE_SEARCH_QUERIES)
+      .await;
+
+    idx_size_title_str += " Clickhouse |";
+    idx_size_dashes_str += " ----- |";
+    idx_size_values_str += &format!(" {} |", cell_clickhouse_index_size);
+
+    idx_lat_title_str += " Clickhouse |"; 
+    idx_lat_dashes_str += " ----- |";
+    idx_lat_values_str += &format!(" {} |", cell_clickhouse_index_time);
+
+    log_search_lat_title_str += " Clickhouse |";
+    log_search_lat_dashes_str += " ----- |";
+    log_search_lat_values_str += &format!(" {} |",
+                  cell_clickhouse_search_time / CLICKHOUSE_SEARCH_QUERIES.len() as u128);
+    // CLICKHOUSE END
+  }
 
   // Metrics related stats
-  // INFINO API FOR METRICS START
-  println!("\n\n***Now running Infino API client for time series***");
 
-  let infino_metrics_client = InfinoMetricsClient::new();
-  // Sleep for 5 seconds to let it collect some data
-  thread::sleep(time::Duration::from_millis(10000));
-  let mut cell_infino_metrics_search_time = 0;
-  for _ in 1..10 {
-    cell_infino_metrics_search_time += infino_metrics_client.search_metrics().await;
+  if run_all || opt.infino_metrics {
+    // INFINO API FOR METRICS START
+    println!("\n\n***Now running Infino API client for time series***");
+
+    let infino_metrics_client = InfinoMetricsClient::new();
+    // Sleep for 5 seconds to let it collect some data
+    thread::sleep(time::Duration::from_millis(10000));
+    let mut cell_infino_metrics_search_time = 0;
+    for _ in 1..10 {
+      cell_infino_metrics_search_time += infino_metrics_client.search_metrics().await;
+    }
+    cell_infino_metrics_search_time /= 10;
+    println!(
+      "Infino metrics search avg {} microseconds",
+      cell_infino_metrics_search_time
+    );
+
+    metrics_search_lat_title_str += " Infino |";
+    metrics_search_lat_dashes_str += " ----- |";
+    metrics_search_lat_values_str += &format!(" {} |", cell_infino_metrics_search_time);
+    // INFINO API FOR METRICS END
   }
-  cell_infino_metrics_search_time /= 10;
-  println!(
-    "Infino metrics search avg {} microseconds",
-    cell_infino_metrics_search_time
-  );
-  // INFINO API FOR METRICS END
 
-  // PROMETHEUS START
-  println!("\n\n***Now running Prometheus for time series***");
+  if run_all || opt.prometheus {
+    // PROMETHEUS START
+    println!("\n\n***Now running Prometheus for time series***");
 
-  let prometheus_client = PrometheusClient::new();
+    let prometheus_client = PrometheusClient::new();
 
-  let append_task = tokio::spawn(async move {
-    prometheus_client.append_ts().await;
-  });
+    let append_task = tokio::spawn(async move {
+      prometheus_client.append_ts().await;
+    });
 
-  // Sleep for 5 seconds to let it collect some data
-  thread::sleep(time::Duration::from_millis(10000));
-  let mut cell_prometheus_search_time = 0;
-  for _ in 1..10 {
-    cell_prometheus_search_time += prometheus_client.search_logs().await;
+    // Sleep for 5 seconds to let it collect some data
+    thread::sleep(time::Duration::from_millis(10000));
+    let mut cell_prometheus_search_time = 0;
+    for _ in 1..10 {
+      cell_prometheus_search_time += prometheus_client.search_logs().await;
+    }
+    cell_prometheus_search_time /= 10;
+    println!(
+      "Prometheus timeseries search avg {} microseconds",
+      cell_prometheus_search_time
+    );
+    prometheus_client.stop();
+
+    append_task.abort();
+
+    metrics_search_lat_title_str += " Prometheus |";
+    metrics_search_lat_dashes_str += " ----- |";
+    metrics_search_lat_values_str += &format!(" {} |", cell_prometheus_search_time);
+
+    // PROMETHEUS END
   }
-  cell_prometheus_search_time /= 10;
-  println!(
-    "Prometheus timeseries search avg {} microseconds",
-    cell_prometheus_search_time
-  );
-  prometheus_client.stop();
-
-  append_task.abort();
-
-  // PROMETHEUS END
 
   // Print the output in markdown
   println!("\n\n## Results: ");
   println!("\nRun date: {}", chrono::Local::now().format("%Y-%m-%d"));
   println!("\nOperating System: {}", std::env::consts::OS);
   println!("\nMachine description: <Please fill in>");
-  println!("\nDataset: {}", input_data_path);
+  println!("\nDataset: {}", &opt.input_file);
   println!("\nDataset size: {}bytes", cell_input_data_size);
   println!();
 
-  let elasticsearch_index_size = if cell_es_index_size == 0 {
-    "<figure out from cat response>".to_owned()
-  } else {
-    cell_es_index_size.to_string()
-  };
+  if run_all ||
+     opt.infino ||
+     opt.infino_rest ||
+     opt.infino_os ||
+     opt.elastic ||
+     opt.clickhouse {
+    println!("\n\n### Index size\n");
+    println!("{}", idx_size_title_str);
+    println!("{}", idx_size_dashes_str);
+    println!("{}", idx_size_values_str);
 
-  println!("\n\n### Index size\n");
-  println!("| dataset | Elasticsearch | Clickhouse | Infino | Infino-Rest |");
-  println!("| ----- | ----- | ----- | ----- | ---- |");
-  println!(
-    "| {} | {} bytes | {} bytes | {} bytes | Same as infino |",
-    input_data_path, elasticsearch_index_size, cell_clickhouse_index_size, cell_infino_index_size,
-  );
+    println!("\n\n### Indexing latency\n");
+    println!("{}", idx_lat_title_str);
+    println!("{}", idx_lat_dashes_str);
+    println!("{}", idx_lat_values_str);
 
-  println!("\n\n### Indexing latency\n");
-  println!("| dataset | Elasticsearch | Clickhouse | Infino | Infino-Rest |");
-  println!("| ----- | ----- | ----- | ----- | ---- |");
-  println!(
-    "| {} | {} microseconds  | {} microseconds  | {} microseconds  | {} microseconds  |",
-    input_data_path,
-    cell_es_index_time,
-    cell_clickhouse_index_time,
-    cell_infino_index_time,
-    cell_infino_rest_index_time
-  );
+    println!("\n\n### Log Search Latency\n");
+    println!("Average across different query types. See the detailed output for granular info.\n");
+    println!("{}", log_search_lat_title_str);
+    println!("{}", log_search_lat_dashes_str);
+    println!("{}", log_search_lat_values_str);
+  }
 
-  println!("\n\n### Log Search Latency\n");
-  println!("Average across different query types. See the detailed output for granular info.\n");
-  println!("| dataset | Elasticsearch | Clickhouse | Infino | Infino-Rest |");
-  println!("| ----- | ----- | ----- | ---- | ---- |");
-  println!(
-    "| {} | {} microseconds  | {} microseconds  | {} microseconds  | {} microseconds  |",
-    input_data_path,
-    cell_es_search_time / ELASTICSEARCH_SEARCH_QUERIES.len() as u128,
-    cell_clickhouse_search_time / CLICKHOUSE_SEARCH_QUERIES.len() as u128,
-    cell_infino_search_time / INFINO_SEARCH_QUERIES.len() as u128,
-    cell_infino_rest_search_time / INFINO_SEARCH_QUERIES.len() as u128
-  );
-
-  println!("\n\n### Metrics Search Latency");
-  println!("\nAverage over 10 queries on metrics.\n");
-  println!("| Metric points | Prometheus | Infino |");
-  println!("| ----------- | ---------- | ---------- |");
-  println!(
-    "| Search Latency | {} microseconds | {} microseconds |\n",
-    cell_prometheus_search_time, cell_infino_metrics_search_time
-  );
+  if run_all || opt.infino_metrics || opt.prometheus {
+    println!("\n\n### Metrics Search Latency");
+    println!("\nAverage over 10 queries on metrics.\n");
+    println!("{}", metrics_search_lat_title_str);
+    println!("{}", metrics_search_lat_dashes_str);
+    println!("{}", metrics_search_lat_values_str);
+  }
 
   Ok(())
 }

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -49,12 +49,16 @@ static ELASTICSEARCH_SEARCH_QUERIES: &[&str] = &[
 struct Opt {
   #[structopt(short, long)]
   stop_after_infino: bool,
+
+  #[structopt(short, long)]
+  stop_after_infino_rest: bool,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
   let opt = Opt::from_args();
   println!("{:#?}", opt.stop_after_infino);
+  println!("{:#?}", opt.stop_after_infino_rest);
 
   // Path to the input data to index from. Points to a log file - where each line is indexed
   // as a separate document in the elasticsearch index and the infino index.
@@ -117,6 +121,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await;
 
   // INFINO REST END
+
+  if opt.stop_after_infino_rest {
+    println!("stop_after_infino_rest is set. Stopping now...");
+    return Ok(());
+  }
 
   // CLICKHOUSE START
   println!("\n\n***Now running Clickhouse***");


### PR DESCRIPTION
Add an infino_os_rest module to benches run benchmark against infino-opensearch. Ingest is done via the infino/_bulk api and search is done via the infino/index/logs/_search api.

Note: The OpenSearch REST plugin changes to implement /_bulk have not merged yet. Meanwhile, there are a bunch of updates to benches (newer -- options) to make it easy to run benches.

## Checklist

- [x]  I have updated the readme file
- [x]  I have benchmark agains infino-rest, infino-opensearch-rest and opensearch
