### PR TITLE
os plugin: update java.policy to allow all headers on all REST methods

### DIFF
--- a/plugins/infino-opensearch-plugin/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/infino-opensearch-plugin/src/main/plugin-metadata/plugin-security.policy
@@ -1,7 +1,6 @@
 grant {
     // Add permissions to allow Infino OpenSearcg Plugin to access Infino using OpenSearch threadpool
     permission org.opensearch.secure_sm.ThreadPermission "modifyArbitraryThread";
-    permission java.net.URLPermission "http://*:*/-", "*";
-    permission java.net.URLPermission "http://*:*/-", "POST:Content-Type";
+    permission java.net.URLPermission "http://*:*/-", "*:*";
     permission java.lang.RuntimePermission "accessUserInformation";
 };


### PR DESCRIPTION
The opensearch plugin currently allows Content-Type header only for POST requests to infino. Some `GET` and `PUT` requests also use the Content-Type header. This change updates the policy to allow any header with any method.