### PR TITLE
feat: support for regexp term query

### DIFF
--- a/coredb/src/request_manager/query_dsl.rs
+++ b/coredb/src/request_manager/query_dsl.rs
@@ -12,7 +12,9 @@
 
 use crate::segment_manager::segment::Segment;
 use crate::utils::error::QueryError;
-use crate::utils::request::{analyze_query_text, analyze_regex_query_text, check_query_time, parse_time_range};
+use crate::utils::request::{
+  analyze_query_text, analyze_regex_query_text, check_query_time, parse_time_range,
+};
 
 use chrono::Utc;
 use futures::StreamExt;
@@ -639,8 +641,9 @@ impl Segment {
 
     match (fieldname, regexp_text) {
       (Some(field), Some(regexp_text_str)) => {
-        let regex_field_term = analyze_regex_query_text(regexp_text_str.trim_matches('"'), field, case_insensitive);
-        
+        let regex_field_term =
+          analyze_regex_query_text(regexp_text_str.trim_matches('"'), field, case_insensitive);
+
         match self
           .get_doc_ids_with_regexp_term(&regex_field_term, case_insensitive)
           .await

--- a/coredb/src/request_manager/query_dsl.rs
+++ b/coredb/src/request_manager/query_dsl.rs
@@ -12,7 +12,7 @@
 
 use crate::segment_manager::segment::Segment;
 use crate::utils::error::QueryError;
-use crate::utils::request::{analyze_query_text, check_query_time, parse_time_range};
+use crate::utils::request::{analyze_query_text, analyze_regex_query_text, check_query_time, parse_time_range};
 
 use chrono::Utc;
 use futures::StreamExt;
@@ -120,6 +120,9 @@ impl Segment {
       }
       Rule::prefix_query => {
         results = self.process_prefix_query(node, timeout).await?;
+      }
+      Rule::regexp_query => {
+        results = self.process_regexp_query(node, timeout).await?;
       }
       _ => {
         return Err(QueryError::UnsupportedQuery(format!(
@@ -600,6 +603,69 @@ impl Segment {
       )),
       (_, None) => Err(QueryError::UnsupportedQuery(
         "Prefix query string is missing".to_string(),
+      )),
+    }
+  }
+
+  /// Regexp Query Processor: https://opensearch.org/docs/latest/query-dsl/term/regexp/
+  async fn process_regexp_query(
+    &self,
+    root_node: &Pair<'_, Rule>,
+    timeout: u64,
+  ) -> Result<QueryDSLDocIds, QueryError> {
+    debug!("QueryDSL: Processing regexp query {:?}", root_node);
+
+    let query_start_time = Utc::now().timestamp_millis() as u64;
+
+    let mut stack: VecDeque<Pair<Rule>> = VecDeque::new();
+    stack.push_back(root_node.clone());
+
+    let mut fieldname: Option<&str> = None;
+    let mut regexp_text: Option<&str> = None;
+    let mut case_insensitive = false;
+
+    while let Some(node) = stack.pop_front() {
+      match node.as_rule() {
+        Rule::fieldname => self.set_fieldname(&node, &mut fieldname),
+        Rule::regexp_string | Rule::value => self.set_query_text(&node, &mut regexp_text),
+        Rule::case_insensitive => self.set_case_insensitive(&node, &mut case_insensitive, false),
+        _ => {
+          for inner_node in node.into_inner() {
+            stack.push_back(inner_node);
+          }
+        }
+      }
+    }
+
+    match (fieldname, regexp_text) {
+      (Some(field), Some(regexp_text_str)) => {
+        let regex_field_term = analyze_regex_query_text(regexp_text_str.trim_matches('"'), field, case_insensitive);
+        
+        match self
+          .get_doc_ids_with_regexp_term(&regex_field_term, case_insensitive)
+          .await
+        {
+          Ok(matching_document_ids) => {
+            let mut results = QueryDSLDocIds::new();
+            let execution_time = check_query_time(timeout, query_start_time)?;
+            results.set_execution_time(execution_time);
+            results.set_ids(matching_document_ids);
+
+            debug!(
+              "QueryDSL: Returning results from regexp query {:?}",
+              results
+            );
+
+            Ok(results)
+          }
+          Err(err) => Err(err),
+        }
+      }
+      (None, _) => Err(QueryError::UnsupportedQuery(
+        "Field name is missing".to_string(),
+      )),
+      (_, None) => Err(QueryError::UnsupportedQuery(
+        "Regexp query string is missing".to_string(),
       )),
     }
   }
@@ -1144,6 +1210,50 @@ mod tests {
             assert!(
               key_field_value.map_or(false, |value| value.starts_with("lo")),
               "Each log should have 'key' field starting with 'lo'."
+            );
+          }
+        }
+        Err(err) => {
+          panic!("Error in search_logs: {:?}", err);
+        }
+      },
+      Err(err) => {
+        panic!("Error parsing query DSL: {:?}", err);
+      }
+    }
+  }
+
+  #[tokio::test]
+  async fn test_search_with_regexp_query() {
+    let segment = create_mock_segment().await;
+
+    let query_dsl_query = r#"{
+        "query": {
+            "regexp": {
+                "key": {
+                    "value": "l[a-z]g"
+                }
+            }
+        }
+    }"#;
+
+    match QueryDslParser::parse(Rule::start, query_dsl_query) {
+      Ok(ast) => match segment.search_logs(&ast, 0, u64::MAX).await {
+        Ok(results) => {
+          assert_eq!(
+            results.get_messages().len(),
+            5,
+            "There should be exactly 5 logs matching the regexp query."
+          );
+
+          for log in results.get_messages().iter() {
+            let key_field_value = log.get_message().get_fields().get("key");
+
+            assert!(
+              key_field_value.map_or(false, |value| regex::Regex::new(r"l[a-z]g")
+                .unwrap()
+                .is_match(value)),
+              "Each log should have 'key' field matching the regexp pattern."
             );
           }
         }

--- a/coredb/src/request_manager/query_dsl_grammar.pest
+++ b/coredb/src/request_manager/query_dsl_grammar.pest
@@ -99,9 +99,9 @@ prefix_terms  = { (case_insensitive | rewrite) }
 
 // Regexp Queries: https://opensearch.org/docs/latest/query-dsl/term/regexp/
 regexp_query  = { start_brace ~ quote ~ "regexp" ~ quote ~ colon ~ regexp_search ~ end_brace }
-regexp_search = { start_brace ~ (regexp_field | (fieldname ~ colon ~ regexp_array)) ~ end_brace }
-regexp_array  = { start_brace ~ (regexp ~ (comma ~ regexp)*)? ~ end_brace }
-regexp        = { (regexp_field | case_insensitive | rewrite | flags | max_determinized_states) }
+regexp_search = { start_brace ~ fieldname ~ colon ~ (regexp_string | regexp_array) ~ end_brace }
+regexp_array  = { start_brace ~ value ~ (comma ~ regexp_terms)* ~ end_brace }
+regexp_terms  = { (case_insensitive | rewrite | flags | max_determinized_states) }
 
 // Wildcard Queries: https://opensearch.org/docs/latest/query-dsl/term/wildcard/
 wildcard_query  = { start_brace ~ quote ~ "wildcard" ~ quote ~ colon ~ wildcard_search ~ end_brace }
@@ -491,6 +491,7 @@ quote_analyzer               = { quote ~ "quote_analyzer" ~ quote ~ colon ~ stri
 quote_field_suffix           = { quote ~ "quote_field_suffix" ~ quote ~ colon ~ string }
 range_filter                 = { quote ~ "range" ~ quote ~ start_brace ~ quote ~ "field" ~ quote ~ colon ~ fieldname ~ comma ~ range_search ~ end_brace }
 regexp_field                 = { fieldname ~ colon ~ string }
+regexp_string                = { string }
 relation                     = { quote ~ "relation" ~ quote ~ colon ~ (quote ~ "INTERSECTS" ~ quote | quote ~ "DISJOINT" ~ quote | quote ~ "WITHIN" ~ quote | quote ~ "CONTAINS" ~ quote) }
 rewrite                      = { quote ~ "rewrite" ~ quote ~ colon ~ quote ~ "" ~ ("constant_score" | "scoring_boolean" | "constant_score_boolean" | "top_terms_N" | "top_terms_boost_N" | "top_terms_blended_freqs_N") ~ quote ~ "" }
 routing                      = { quote ~ "routing" ~ quote ~ colon ~ string }

--- a/coredb/src/segment_manager/search_logs.rs
+++ b/coredb/src/segment_manager/search_logs.rs
@@ -583,14 +583,14 @@ impl Segment {
             is_escaping = true;
           }
         }
-        '*' | '?' | '+'  | '[' | ']' => {
+        '*' | '?' | '+' | '[' | ']' => {
           if !is_escaping {
             break;
           }
           prefix.push(c);
         }
         _ => {
-          if !is_escaping  {
+          if !is_escaping {
             prefix.push(c);
           }
           is_escaping = false;

--- a/coredb/src/segment_manager/search_logs.rs
+++ b/coredb/src/segment_manager/search_logs.rs
@@ -529,6 +529,77 @@ impl Segment {
 
     matching_document_ids
   }
+  /// Retrieve document IDs with regular expression term match.
+  ///
+  /// # Arguments
+  ///
+  /// * `regexp_term` - A regular expression term to match.
+  /// * `field` - The field to search within.
+  /// * `case_insensitive` - A boolean flag indicating whether the search is case-insensitive.
+
+  pub async fn get_doc_ids_with_regexp_term(
+    &self,
+    regexp_term: &str,
+    case_insensitive: bool,
+  ) -> Result<Vec<u32>, QueryError> {
+    let regex = Regex::new(regexp_term);
+
+    // Get terms with the prefix formed by the regular expression
+    let prefix_matches =
+      self.get_terms_with_prefix(&self.regexp_to_prefix(regexp_term), case_insensitive);
+
+    let regex = match regex {
+      Ok(regex) => regex,
+      Err(err) => {
+        eprintln!("Error: {}", err);
+        return Err(QueryError::RegexpError(err.to_string()));
+      }
+    };
+
+    // Check all the terms for regex match
+    let matching_terms: Vec<String> = prefix_matches
+      .into_iter()
+      .filter(|term| regex.is_match(term.as_bytes()))
+      .collect();
+
+    // Search inverted index for matching terms
+    let or_doc_ids = self.search_inverted_index(matching_terms, "OR").await?;
+
+    Ok(or_doc_ids)
+  }
+
+  /// Converts a regular expression pattern into a prefix suitable for prefix matching.
+  fn regexp_to_prefix(&self, regexp: &str) -> String {
+    let mut prefix = String::new();
+    let mut is_escaping = false;
+
+    for c in regexp.chars() {
+      match c {
+        '\\' => {
+          if is_escaping {
+            prefix.push(c);
+            is_escaping = false;
+          } else {
+            is_escaping = true;
+          }
+        }
+        '*' | '?' | '+'  | '[' | ']' => {
+          if !is_escaping {
+            break;
+          }
+          prefix.push(c);
+        }
+        _ => {
+          if !is_escaping  {
+            prefix.push(c);
+          }
+          is_escaping = false;
+        }
+      }
+    }
+
+    prefix
+  }
 
   /// Retrieve document IDs with prefix phrase match.
   ///

--- a/coredb/src/utils/error.rs
+++ b/coredb/src/utils/error.rs
@@ -116,6 +116,9 @@ pub enum QueryError {
 
   #[error("No query provided")]
   NoQueryProvided,
+
+  #[error("Regexp Error: {0}")]
+  RegexpError(String),
 }
 
 impl From<object_store::Error> for CoreDBError {

--- a/coredb/src/utils/request.rs
+++ b/coredb/src/utils/request.rs
@@ -104,3 +104,26 @@ pub async fn analyze_query_text(
 
   transformed_terms
 }
+
+
+pub fn analyze_regex_query_text(
+  regex_query_text: &str,
+  fieldname: &str,
+  case_insensitive: bool,
+) -> String {
+  debug!(
+    "Analyze text: Processing regexp query {:?} {:?} {:?}",
+    regex_query_text, fieldname, case_insensitive
+  );
+
+  let query = if case_insensitive {
+    regex_query_text.to_lowercase()
+  } else {
+    regex_query_text.to_owned()
+  };
+
+
+  let regex_field_term = format!("{}{}{}", fieldname, FIELD_DELIMITER, query); // Prepare the prefix once
+
+  regex_field_term
+}

--- a/coredb/src/utils/request.rs
+++ b/coredb/src/utils/request.rs
@@ -105,7 +105,6 @@ pub async fn analyze_query_text(
   transformed_terms
 }
 
-
 pub fn analyze_regex_query_text(
   regex_query_text: &str,
   fieldname: &str,
@@ -121,7 +120,6 @@ pub fn analyze_regex_query_text(
   } else {
     regex_query_text.to_owned()
   };
-
 
   let regex_field_term = format!("{}{}{}", fieldname, FIELD_DELIMITER, query); // Prepare the prefix once
 

--- a/coredb/src/utils/request.rs
+++ b/coredb/src/utils/request.rs
@@ -121,7 +121,7 @@ pub fn analyze_regex_query_text(
     regex_query_text.to_owned()
   };
 
-  let regex_field_term = format!("{}{}{}", fieldname, FIELD_DELIMITER, query); // Prepare the prefix once
+  let regex_field_term = format!("{}{}{}", fieldname, FIELD_DELIMITER, query);
 
   regex_field_term
 }


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
- Added support for regexp term queries.

## How does this PR work? (optional)
- Convert the regexp into possible prefix, and use trie for all possibly matching terms 
- From those terms, match regex and filter the useful terms.
- Get the docs with those final terms.

## Refer to a related PR or issue link
- N.A.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
