### PR TITLE
feat: added support for wildcard term queries

### DIFF
--- a/coredb/src/request_manager/query_dsl_grammar.pest
+++ b/coredb/src/request_manager/query_dsl_grammar.pest
@@ -105,8 +105,9 @@ regexp_terms  = { (case_insensitive | rewrite | flags | max_determinized_states)
 
 // Wildcard Queries: https://opensearch.org/docs/latest/query-dsl/term/wildcard/
 wildcard_query  = { start_brace ~ quote ~ "wildcard" ~ quote ~ colon ~ wildcard_search ~ end_brace }
-wildcard_search = { start_brace ~ fieldname ~ colon ~ start_brace ~ (wildcard ~ (comma ~ wildcard)*)? ~ end_brace ~ end_brace }
-wildcard        = { (wildcard_value | boost | case_insensitive) }
+wildcard_search = { start_brace ~ fieldname ~ colon ~ (wildcard_string | wildcard_array) ~ end_brace }
+wildcard_array  = { start_brace ~ value ~ (comma ~ wildcard_terms)* ~ end_brace }
+wildcard_terms  = { (boost | case_insensitive) }
 
 // Fuzzy Queries: https://opensearch.org/docs/latest/query-dsl/term/fuzzy/
 fuzzy_query  = { start_brace ~ quote ~ "fuzzy" ~ quote ~ colon ~ fuzzy_search ~ end_brace }
@@ -521,6 +522,7 @@ wildcard_before              = { quote ~ "before" ~ quote ~ colon ~ string }
 wildcard_not_after           = { quote ~ "not_after" ~ quote ~ colon ~ string }
 wildcard_not_before          = { quote ~ "not_before" ~ quote ~ colon ~ string }
 wildcard_not_within          = { quote ~ "not_within" ~ quote ~ colon ~ string }
+wildcard_string              = { string }
 wildcard_value               = { quote ~ "value" ~ quote ~ colon ~ string }
 wildcard_within              = { quote ~ "within" ~ quote ~ colon ~ string }
 within                       = { quote ~ "within" ~ quote ~ colon ~ integer }

--- a/coredb/src/segment_manager/search_logs.rs
+++ b/coredb/src/segment_manager/search_logs.rs
@@ -529,12 +529,12 @@ impl Segment {
 
     matching_document_ids
   }
+
   /// Retrieve document IDs with regular expression term match.
   ///
   /// # Arguments
   ///
   /// * `regexp_term` - A regular expression term to match.
-  /// * `field` - The field to search within.
   /// * `case_insensitive` - A boolean flag indicating whether the search is case-insensitive.
 
   pub async fn get_doc_ids_with_regexp_term(
@@ -569,6 +569,7 @@ impl Segment {
   }
 
   /// Converts a regular expression pattern into a prefix suitable for prefix matching.
+  /// TODO: This method needs to be more nuanced to handle OR (|), Negations (~), and complex regex operators
   fn regexp_to_prefix(&self, regexp: &str) -> String {
     let mut prefix = String::new();
     let mut is_escaping = false;
@@ -583,7 +584,7 @@ impl Segment {
             is_escaping = true;
           }
         }
-        '*' | '?' | '+' | '[' | ']' => {
+        '*' | '?' | '+' | '[' | ']' | '.' | '|' | '$' => {
           if !is_escaping {
             break;
           }
@@ -599,6 +600,68 @@ impl Segment {
     }
 
     prefix
+  }
+
+  /// Retrieve document IDs with wildcard expression term match.
+  ///
+  /// # Arguments
+  ///
+  /// * `wildcard_term` - A wildcard expression term to match.
+  /// * `case_insensitive` - A boolean flag indicating whether the search is case-insensitive.
+
+  pub async fn get_doc_ids_with_wildcard_term(
+    &self,
+    wildcard_term: &str,
+    case_insensitive: bool,
+  ) -> Result<Vec<u32>, QueryError> {
+    // Convert wildcard term to regex pattern
+    let regex_pattern = self.wildcard_to_regex(wildcard_term);
+
+    // Use the existing method for regex to get document IDs
+    self
+      .get_doc_ids_with_regexp_term(&regex_pattern, case_insensitive)
+      .await
+  }
+
+  /// Converts a wildcard query pattern into a regex pattern.
+  fn wildcard_to_regex(&self, wildcard: &str) -> String {
+    let mut regex_pattern = String::new();
+    let mut is_escaping = false;
+
+    for c in wildcard.chars() {
+      match c {
+        '\\' => {
+          if is_escaping {
+            regex_pattern.push(c);
+            is_escaping = false;
+          } else {
+            is_escaping = true;
+          }
+        }
+        '*' => {
+          if !is_escaping {
+            regex_pattern.push_str(".*");
+          } else {
+            regex_pattern.push(c);
+          }
+          is_escaping = false;
+        }
+        '?' => {
+          if !is_escaping {
+            regex_pattern.push('.');
+          } else {
+            regex_pattern.push(c);
+          }
+          is_escaping = false;
+        }
+        _ => {
+          regex_pattern.push(c);
+          is_escaping = false;
+        }
+      }
+    }
+
+    regex_pattern
   }
 
   /// Retrieve document IDs with prefix phrase match.


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
- Added support for wildcard term queries.

## How does this PR work? (optional)
- Convert the wildcard term to an equivalent regex
- Use the existing method to get matching doc ids from the regex terms
- Note: `regexp_to_prefix` method needs to be more nuanced to handle OR (|), Negations (~), and complex regex operators

## Refer to a related PR or issue link
- N.A. 

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
