### PR TITLE
feat: support for match phrase prefix query

### DIFF
--- a/coredb/src/request_manager/query_dsl.rs
+++ b/coredb/src/request_manager/query_dsl.rs
@@ -752,7 +752,10 @@ impl Segment {
     root_node: &Pair<'_, Rule>,
     timeout: u64,
   ) -> Result<QueryDSLDocIds, QueryError> {
-    debug!("QueryDSL: Processing match phrase prefix query {:?}", root_node);
+    debug!(
+      "QueryDSL: Processing match phrase prefix query {:?}",
+      root_node
+    );
 
     let query_start_time = Utc::now().timestamp_millis() as u64;
 

--- a/coredb/src/request_manager/query_dsl.rs
+++ b/coredb/src/request_manager/query_dsl.rs
@@ -354,9 +354,9 @@ impl Segment {
       let analyzed_query = analyze_query_text(query_str, fieldname, case_insensitive).await;
       let search_results = self.search_inverted_index(analyzed_query, "AND").await?;
 
+      results.set_ids(search_results);
       let execution_time = check_query_time(timeout, query_start_time)?;
       results.set_execution_time(execution_time);
-      results.set_ids(search_results);
     } else {
       return Err(QueryError::UnsupportedQuery(
         "Query string is missing".to_string(),
@@ -414,9 +414,10 @@ impl Segment {
     if !query_terms.is_empty() {
       let search_results = self.search_inverted_index(query_terms, "OR").await?;
 
+      results.set_ids(search_results);
+
       let execution_time = check_query_time(timeout, query_start_time)?;
       results.set_execution_time(execution_time);
-      results.set_ids(search_results);
     } else {
       return Err(QueryError::UnsupportedQuery(
         "No query terms found".to_string(),
@@ -470,9 +471,11 @@ impl Segment {
         .search_inverted_index(analyzed_query, term_operator)
         .await?;
 
-      let execution_time = check_query_time(timeout, query_start_time)?;
-      results.set_execution_time(execution_time);
       results.set_ids(search_results);
+
+      let execution_time = check_query_time(timeout, query_start_time)?;
+
+      results.set_execution_time(execution_time);
     } else {
       return Err(QueryError::UnsupportedQuery(
         "Query string is missing".to_string(),
@@ -528,9 +531,9 @@ impl Segment {
         let matching_document_ids =
           self.get_exact_phrase_matches(&search_result, Some(field), query_str.trim_matches('"'));
 
+        results.set_ids(matching_document_ids);
         let execution_time = check_query_time(timeout, query_start_time)?;
         results.set_execution_time(execution_time);
-        results.set_ids(matching_document_ids);
 
         debug!(
           "QueryDSL: Returning results from match phrase query {:?}",
@@ -595,9 +598,11 @@ impl Segment {
         {
           Ok(matching_document_ids) => {
             let mut results = QueryDSLDocIds::new();
+
+            results.set_ids(matching_document_ids);
+
             let execution_time = check_query_time(timeout, query_start_time)?;
             results.set_execution_time(execution_time);
-            results.set_ids(matching_document_ids);
 
             debug!(
               "QueryDSL: Returning results from prefix query {:?}",
@@ -659,9 +664,11 @@ impl Segment {
         {
           Ok(matching_document_ids) => {
             let mut results = QueryDSLDocIds::new();
+
+            results.set_ids(matching_document_ids);
+
             let execution_time = check_query_time(timeout, query_start_time)?;
             results.set_execution_time(execution_time);
-            results.set_ids(matching_document_ids);
 
             debug!(
               "QueryDSL: Returning results from regexp query {:?}",
@@ -723,9 +730,11 @@ impl Segment {
         {
           Ok(matching_document_ids) => {
             let mut results = QueryDSLDocIds::new();
+
+            results.set_ids(matching_document_ids);
+
             let execution_time = check_query_time(timeout, query_start_time)?;
             results.set_execution_time(execution_time);
-            results.set_ids(matching_document_ids);
 
             debug!(
               "QueryDSL: Returning results from wildcard query {:?}",
@@ -796,9 +805,9 @@ impl Segment {
         {
           Ok(matching_document_ids) => {
             let mut results = QueryDSLDocIds::new();
+            results.set_ids(matching_document_ids);
             let execution_time = check_query_time(timeout, query_start_time)?;
             results.set_execution_time(execution_time);
-            results.set_ids(matching_document_ids);
 
             debug!(
               "QueryDSL: Returning results from match phrase prefix query {:?}",

--- a/coredb/src/request_manager/query_dsl.rs
+++ b/coredb/src/request_manager/query_dsl.rs
@@ -129,6 +129,11 @@ impl Segment {
       Rule::wildcard_query => {
         results = self.process_wildcard_query(node, timeout).await?;
       }
+      Rule::match_phrase_prefix_query => {
+        results = self
+          .process_match_phrase_prefix_query(node, timeout)
+          .await?;
+      }
       _ => {
         return Err(QueryError::UnsupportedQuery(format!(
           "Unsupported rule: {:?}",
@@ -579,11 +584,12 @@ impl Segment {
           analyze_query_text(prefix_text_str, Some(field), case_insensitive).await;
 
         match self
-          .get_doc_ids_with_prefix_phrase(
+          .get_doc_ids_with_prefix_term_or_full_text_phrase(
             prefix_phrase_terms,
             field,
             prefix_text_str.trim_matches('"'),
             case_insensitive,
+            false,
           )
           .await
         {
@@ -739,6 +745,76 @@ impl Segment {
       )),
     }
   }
+
+  /// Match Phrase Prefix Query Processor: https://opensearch.org/docs/latest/query-dsl/full-text/match-phrase-prefix/
+  async fn process_match_phrase_prefix_query(
+    &self,
+    root_node: &Pair<'_, Rule>,
+    timeout: u64,
+  ) -> Result<QueryDSLDocIds, QueryError> {
+    debug!("QueryDSL: Processing match phrase prefix query {:?}", root_node);
+
+    let query_start_time = Utc::now().timestamp_millis() as u64;
+
+    let mut stack: VecDeque<Pair<Rule>> = VecDeque::new();
+    stack.push_back(root_node.clone());
+
+    let mut fieldname: Option<&str> = None;
+    let mut query_text: Option<&str> = None;
+
+    while let Some(node) = stack.pop_front() {
+      match node.as_rule() {
+        Rule::fieldname => self.set_fieldname(&node, &mut fieldname),
+        Rule::match_phrase_prefix_string | Rule::query => {
+          self.set_query_text(&node, &mut query_text)
+        }
+        _ => {
+          for inner_node in node.into_inner() {
+            stack.push_back(inner_node);
+          }
+        }
+      }
+    }
+
+    match (fieldname, query_text) {
+      (Some(field), Some(query_str)) => {
+        let prefix_phrase_terms: Vec<String> =
+          analyze_query_text(query_str, Some(field), false).await;
+
+        match self
+          .get_doc_ids_with_prefix_term_or_full_text_phrase(
+            prefix_phrase_terms,
+            field,
+            query_str.trim_matches('"'),
+            false,
+            true,
+          )
+          .await
+        {
+          Ok(matching_document_ids) => {
+            let mut results = QueryDSLDocIds::new();
+            let execution_time = check_query_time(timeout, query_start_time)?;
+            results.set_execution_time(execution_time);
+            results.set_ids(matching_document_ids);
+
+            debug!(
+              "QueryDSL: Returning results from match phrase prefix query {:?}",
+              results
+            );
+
+            Ok(results)
+          }
+          Err(err) => Err(err),
+        }
+      }
+      (None, _) => Err(QueryError::UnsupportedQuery(
+        "Field name is missing".to_string(),
+      )),
+      (_, None) => Err(QueryError::UnsupportedQuery(
+        "Query string is missing".to_string(),
+      )),
+    }
+  }
 }
 
 #[cfg(test)]
@@ -764,6 +840,10 @@ mod tests {
       ("log 3 1", "test log for different term"),
       ("log 4", "field1~field1value testing field name and value"),
       ("log 5", "field1~field2value testing field name two value"),
+      (
+        "test temp long 5",
+        "field2~field3value testing match phrase prefix",
+      ),
     ];
 
     for (key, message) in log_messages.iter() {
@@ -1356,8 +1436,8 @@ mod tests {
         Ok(results) => {
           assert_eq!(
             results.get_messages().len(),
-            5,
-            "There should be exactly 5 logs matching the wildcard query."
+            6,
+            "There should be exactly 6 logs matching the wildcard query."
           );
 
           for log in results.get_messages().iter() {
@@ -1394,6 +1474,48 @@ mod tests {
             .get_messages()
             .iter()
             .all(|log| log.get_message().get_text().contains("field1~field1value")));
+        }
+        Err(err) => {
+          panic!("Error in search_logs: {:?}", err);
+        }
+      },
+      Err(err) => {
+        panic!("Error parsing query DSL: {:?}", err);
+      }
+    }
+  }
+
+  #[tokio::test]
+  async fn test_search_with_match_phrase_prefix_query() {
+    let segment = create_mock_segment().await;
+
+    let query_dsl_query = r#"{
+        "query": {
+            "match_phrase_prefix": {
+                "key": {
+                    "query": "temp lo"
+                }
+            }
+        }
+    }"#;
+
+    match QueryDslParser::parse(Rule::start, query_dsl_query) {
+      Ok(ast) => match segment.search_logs(&ast, 0, u64::MAX).await {
+        Ok(results) => {
+          assert_eq!(
+            results.get_messages().len(),
+            1,
+            "There should be exactly 1 log matching the query."
+          );
+
+          for log in results.get_messages() {
+            let key_field_value = log.get_message().get_fields().get("key");
+
+            assert!(
+              key_field_value.map_or(false, |value| value.contains("temp lo")),
+              "Each log should have 'key' field containing 'temp lo'."
+            );
+          }
         }
         Err(err) => {
           panic!("Error in search_logs: {:?}", err);

--- a/coredb/src/request_manager/query_dsl_grammar.pest
+++ b/coredb/src/request_manager/query_dsl_grammar.pest
@@ -141,9 +141,9 @@ match_phrase_terms  = { (analyzer | slop | zero_terms_query) }
 
 // Match Phrase Queries: https://opensearch.org/docs/latest/query-dsl/full-text/match-phrase/
 match_phrase_prefix_query  = { start_brace ~ quote ~ "match_phrase_prefix" ~ quote ~ colon ~ match_phrase_prefix_search ~ end_brace }
-match_phrase_prefix_search = { start_brace ~ fieldname ~ colon ~ match_phrase_prefix_array ~ end_brace }
-match_phrase_prefix_array  = { start_brace ~ query ~ (comma ~ match_phrase_prefix)* ~ end_brace }
-match_phrase_prefix        = { (analyzer | slop | zero_terms_query) }
+match_phrase_prefix_search = { start_brace ~ fieldname ~ colon ~ ( match_phrase_prefix_string | match_phrase_prefix_array )~ end_brace }
+match_phrase_prefix_array  = { start_brace ~ query ~ (comma ~ match_phrase_prefix_terms)* ~ end_brace }
+match_phrase_prefix_terms  = { (analyzer | slop | zero_terms_query) }
 
 // Multi Match Queries: https://opensearch.org/docs/latest/query-dsl/full-text/multi-match/
 multi_match_query  = { start_brace ~ quote ~ "multi_match" ~ quote ~ colon ~ multi_match_search ~ end_brace }
@@ -449,6 +449,7 @@ line_string                  = { geo_type ~ "lineString" ~ quote ~ "" ~ comma ~ 
 linear_ring                  = { start_bracket ~ (geo_coordinate ~ (comma ~ geo_coordinate)*)? ~ end_bracket }
 lt                           = { quote ~ "lt" ~ quote ~ colon ~ (number | date) }
 lte                          = { quote ~ "lte" ~ quote ~ colon ~ (number | date) }
+match_phrase_prefix_string   = { string }
 match_phrase_string          = { string }
 match_string                 = { string }
 max_boost                    = { quote ~ "max_boost" ~ quote ~ colon ~ float }

--- a/coredb/src/segment_manager/search_logs.rs
+++ b/coredb/src/segment_manager/search_logs.rs
@@ -672,13 +672,15 @@ impl Segment {
   /// * `field` - The field to search within.
   /// * `prefix_text_str` - The exact prefix text string to match.
   /// * `case_insensitive` - A boolean flag indicating whether the search is case-insensitive.
+  /// * `is_full_text_phrase` - Signifies whether it is term query or match phase query, for differentiating in the matching logic
   ///
-  pub async fn get_doc_ids_with_prefix_phrase(
+  pub async fn get_doc_ids_with_prefix_term_or_full_text_phrase(
     &self,
     prefix_phrase_terms: Vec<String>,
     field: &str,
     prefix_text_str: &str,
     case_insensitive: bool,
+    is_full_text_phrase: bool,
   ) -> Result<Vec<u32>, QueryError> {
     let mut matching_document_ids = Vec::new();
 
@@ -718,15 +720,25 @@ impl Segment {
 
       or_doc_ids.dedup();
 
-      // From the given document IDs, filter document IDs which start with the exact phrase (in the given field)
-      // and return the specific document IDs
+      if is_full_text_phrase {
+        // From the given document IDs, filter document IDs which contain the exact phrase (in the given field)
+        // and return the specific document IDs
+        matching_document_ids.extend(self.get_exact_phrase_matches(
+          &or_doc_ids,
+          Some(field),
+          prefix_text_str,
+        ));
+      } else {
+        // From the given document IDs, filter document IDs which start with the exact phrase (in the given field)
+        // and return the specific document IDs
 
-      matching_document_ids.extend(self.get_bool_prefix_matches(
-        &or_doc_ids,
-        field,
-        prefix_text_str,
-        case_insensitive,
-      ));
+        matching_document_ids.extend(self.get_bool_prefix_matches(
+          &or_doc_ids,
+          field,
+          prefix_text_str,
+          case_insensitive,
+        ));
+      }
     }
 
     Ok(matching_document_ids)


### PR DESCRIPTION
<!--

Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change below.

Please make sure you always link a PR to a particular issue.

Happy contributing!

-->

## What does this PR do?
- Added support for "match phrase prefix" queries.

## How does this PR work? (optional)
- Updated the existing method (`get_doc_ids_with_prefix_term_or_full_text_phrase`) for the "prefix term" query to handle the final logic of "match phrase prefix" which can be anywhere in the field, and not necessarily only "starts with it". 

## Refer to a related PR or issue link
- N.A

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests. (for non-documentation changes)
