### PR TITLE
Minor: update rustfmt.toml to allow vscode to format rust files

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 tab_spaces = 2
+edition = "2021"


### PR DESCRIPTION
## Why this change
Using vscode to format rust files were failing as vscode uses rustfmt (through rust-analyzer) and by default rustfmt is using `edition=2015` which does not recogonize some of the newer features we use. In our Cargo.toml we set `edition=2021`, but this is only picked up by `cargo fmt` and not `rustfmt`. vscode uses rustfmt.

So adding `edition=2021` to rustfmt.toml. 

With this change, vscode can format rust files by ⇒ Open `Command Palette` → `Format Document`. Or vscode is set to format on save, it will format the whole file on saving. To disable formatOnSave you can use below config in vscode's settings.json

```
"editor.formatOnSave": false
```

To disable autoformatting on save only for rust files and format manually by invoking ⇒ Open `Command Palette` → `Format Document` , you can use 

```
 "[rust]": {
    "editor.formatOnSave": false
  }
  ```
  
## This may help (was tricky to figure out)
rustfmt does not support format sections of a file. vscode has the option to format only newer modifications to a file on save (`"editor.formatOnSaveMode": "modifications"`). This vscode setting does not work with rustfmt. If you have vscode set to format only modifications on save, disable it for rust as follows.

```
 "[rust]": {
    "editor.formatOnSave": false
    "editor.formatOnSaveMode": "file"
  }
  ```

If vscode complains that default formatter for rust is not set, add the `editor.defaultFormatter` config to rust as follows

```
 "[rust]": {
    "editor.formatOnSave": false
    "editor.defaultFormatter": "rust-lang.rust-analyzer",
    "editor.formatOnSaveMode": "file"
  }
  ```

